### PR TITLE
Refactoring of wares initialization and introduction of datastore in wares

### DIFF
--- a/src/apps/openfluid-engine/OpenFLUID.cpp
+++ b/src/apps/openfluid-engine/OpenFLUID.cpp
@@ -507,7 +507,7 @@ void OpenFLUIDApp::runSimulation()
   std::cout << "* Loading data... " << std::endl; std::cout.flush();
   openfluid::fluidx::FluidXDescriptor FXDesc(IOListener);
   FXDesc.loadFromDirectory(openfluid::base::RuntimeEnvironment::getInstance()->getInputDir());
-  std::cout << "[OK]" << std::endl; std::cout.flush();
+
 
   std::cout << "* Building spatial domain... "; std::cout.flush();
   openfluid::machine::Factory::buildSimulationBlobFromDescriptors(FXDesc,m_SimBlob);
@@ -519,7 +519,7 @@ void OpenFLUIDApp::runSimulation()
                                                                 Model);
   std::cout << "[OK]" << std::endl; std::cout.flush();
 
-  std::cout << "* Building observers list... "; std::cout.flush();
+  std::cout << "* Building monitoring... "; std::cout.flush();
   openfluid::machine::Factory::buildMonitoringInstanceFromDescriptor(FXDesc.getMonitoringDescriptor(),
                                                                 Monitoring);
   std::cout << "[OK]" << std::endl; std::cout.flush();

--- a/src/openfluid/machine/ModelInstance.cpp
+++ b/src/openfluid/machine/ModelInstance.cpp
@@ -338,6 +338,7 @@ void ModelInstance::initialize(openfluid::base::SimulationLogger* SimLogger)
     CurrentFunction->Body->linkToSimulation(&(m_SimulationBlob.getSimulationStatus()));
     CurrentFunction->Body->linkToRunEnvironment(openfluid::base::RuntimeEnvironment::getInstance()->getWareEnvironment());
     CurrentFunction->Body->linkToCoreRepository(&(m_SimulationBlob.getCoreRepository()));
+    CurrentFunction->Body->linkToDatastore(&(m_SimulationBlob.getDatastore()));
     CurrentFunction->Body->initializeWare(CurrentFunction->Signature->ID,
                                     openfluid::base::RuntimeEnvironment::getInstance()->getFunctionsMaxNumThreads());
     FuncSequence.push_back(CurrentFunction->Signature->ID);

--- a/src/openfluid/machine/MonitoringInstance.cpp
+++ b/src/openfluid/machine/MonitoringInstance.cpp
@@ -117,6 +117,7 @@ void MonitoringInstance::initialize(openfluid::base::SimulationLogger* SimLogger
     CurrentObserver->Body->linkToSimulation(&(m_SimulationBlob.getSimulationStatus()));
     CurrentObserver->Body->linkToRunEnvironment(openfluid::base::RuntimeEnvironment::getInstance()->getWareEnvironment());
     CurrentObserver->Body->linkToCoreRepository(&(m_SimulationBlob.getCoreRepository()));
+    CurrentObserver->Body->linkToDatastore(&(m_SimulationBlob.getDatastore()));
     CurrentObserver->Body->initializeWare(CurrentObserver->Signature->ID);
 
     ObsIter++;

--- a/src/openfluid/ware/PluggableFunction.cpp
+++ b/src/openfluid/ware/PluggableFunction.cpp
@@ -70,9 +70,8 @@ namespace openfluid { namespace ware {
 
 
 PluggableFunction::PluggableFunction()
-  : SimulationContributorWare(),
-    m_MaxThreads(openfluid::config::FUNCTIONS_MAXNUMTHREADS),
-    m_Initialized(false)
+  : SimulationContributorWare(FUNCTION),
+    m_MaxThreads(openfluid::config::FUNCTIONS_MAXNUMTHREADS)
 {
 
 }

--- a/src/openfluid/ware/PluggableFunction.hpp
+++ b/src/openfluid/ware/PluggableFunction.hpp
@@ -143,8 +143,6 @@ class DLLEXPORT PluggableFunction : public SimulationContributorWare
 
     unsigned int m_MaxThreads;
 
-    bool m_Initialized;
-
     static std::string generateDotEdge(std::string SrcClass, std::string SrcID,
                                        std::string DestClass, std::string DestID,
                                        std::string Options);

--- a/src/openfluid/ware/PluggableObserver.cpp
+++ b/src/openfluid/ware/PluggableObserver.cpp
@@ -60,7 +60,7 @@
 namespace openfluid { namespace ware {
 
 
-PluggableObserver::PluggableObserver() : SimulationInspectorWare()
+PluggableObserver::PluggableObserver() : SimulationInspectorWare(OBSERVER)
 {
 
 }
@@ -75,6 +75,17 @@ PluggableObserver::~PluggableObserver()
   finalizeWare();
 }
 
+
+// =====================================================================
+// =====================================================================
+
+
+void PluggableObserver::initializeWare(const WareID_t& ID)
+{
+  if (m_Initialized) return;
+
+  SimulationInspectorWare::initializeWare(ID);
+}
 
 
 }  // namespace ware

--- a/src/openfluid/ware/PluggableObserver.hpp
+++ b/src/openfluid/ware/PluggableObserver.hpp
@@ -109,11 +109,21 @@ namespace openfluid { namespace ware {
 
 class DLLEXPORT PluggableObserver : public SimulationInspectorWare
 {
+  private:
+
+    bool m_Initialized;
+
+
   public:
 
     PluggableObserver();
 
     virtual ~PluggableObserver();
+
+    /**
+       Internally called by the framework.
+     */
+    void initializeWare(const WareID_t& FuncID);
 
     /**
        Initializes function parameters of the function, given as a hash map. Internally called by the framework.

--- a/src/openfluid/ware/PluggableWare.cpp
+++ b/src/openfluid/ware/PluggableWare.cpp
@@ -128,18 +128,24 @@ bool PluggableWare::OPENFLUID_GetRunEnvironment(std::string Key, bool *Value)
 void PluggableWare::initializeWare(const WareID_t& ID)
 {
   if(!isLinked())
-    throw openfluid::base::OFException("initialized ware that is not fully linked");
+    throw openfluid::base::OFException("initialized ware that is not fully linked ("+ID+")");
 
   m_WareID = ID;
 
   // initialize loggers
   std::string LogFile;
   std::string LogDir;
+  std::string LogFileSuffix = "_undefined";
+
+  if (m_WareType == FUNCTION) LogFileSuffix = openfluid::config::FUNCTIONS_PLUGINS_SUFFIX;
+  if (m_WareType == OBSERVER) LogFileSuffix = openfluid::config::OBSERVERS_PLUGINS_SUFFIX;
 
   OPENFLUID_GetRunEnvironment("dir.output",&LogDir);
-  LogFile = boost::filesystem::path(LogDir + "/" + m_WareID + ".log").string();
+  LogFile = boost::filesystem::path(LogDir + "/" + m_WareID + LogFileSuffix + ".log").string();
 
   OPENFLUID_Logger.open(LogFile.c_str());
+
+  m_Initialized = true;
 };
 
 

--- a/src/openfluid/ware/PluggableWare.hpp
+++ b/src/openfluid/ware/PluggableWare.hpp
@@ -100,6 +100,11 @@ typedef boost::property_tree::ptree WareParams_t;
 
 class DLLEXPORT PluggableWare
 {
+  public:
+
+    enum WareType { UNDEFINED, OBSERVER, FUNCTION };
+
+
   private:
 
     /**
@@ -115,7 +120,9 @@ class DLLEXPORT PluggableWare
 
   protected:
 
-    bool isLinked() { return (mp_WareEnv != NULL && mp_SimLogger != NULL); };
+    virtual bool isLinked() const { return (mp_WareEnv != NULL && mp_SimLogger != NULL); };
+
+    bool m_Initialized;
 
     /**
       Pointer to the execution messages repository
@@ -167,16 +174,18 @@ class DLLEXPORT PluggableWare
     */
     bool OPENFLUID_GetRunEnvironment(std::string Key, bool *Val);
 
-    WareID_t OPENFLUID_GetWareID() { return m_WareID; };
+    WareID_t OPENFLUID_GetWareID() const { return m_WareID; };
 
     openfluid::base::StdoutAndFileOutputStream OPENFLUID_Logger;
 
+    WareType m_WareType;
+
+
+    PluggableWare(WareType WType)
+    : mp_WareEnv(NULL),m_WareID(""),m_Initialized(false),mp_SimLogger(NULL), m_WareType(WType)
+    { };
 
   public:
-
-    PluggableWare()
-    : mp_WareEnv(NULL),m_WareID(""),mp_SimLogger(NULL)
-    {};
 
     virtual ~PluggableWare() {};
 
@@ -190,7 +199,7 @@ class DLLEXPORT PluggableWare
       mp_WareEnv = Env;
     };
 
-    void initializeWare(const WareID_t& ID);
+    virtual void initializeWare(const WareID_t& ID);
 
     void finalizeWare();
 

--- a/src/openfluid/ware/SimulationContributorWare.hpp
+++ b/src/openfluid/ware/SimulationContributorWare.hpp
@@ -422,10 +422,12 @@ class DLLEXPORT SimulationContributorWare : public SimulationInspectorWare
                                     const unsigned int& ColsNbr,
                                     const unsigned int& RowsNbr);
 
+    SimulationContributorWare(WareType WType) : SimulationInspectorWare(WType)
+    {};
+
+
   public:
 
-    SimulationContributorWare() : SimulationInspectorWare()
-    {};
 
     virtual ~SimulationContributorWare() {};
 

--- a/src/openfluid/ware/SimulationDrivenWare.hpp
+++ b/src/openfluid/ware/SimulationDrivenWare.hpp
@@ -88,7 +88,7 @@ class DLLEXPORT SimulationDrivenWare : public PluggableWare
 
   protected:
 
-    bool isLinked() { return (PluggableWare::isLinked() && mp_SimStatus != NULL); };
+    virtual bool isLinked() const { return (PluggableWare::isLinked() && mp_SimStatus != NULL); };
 
     openfluid::core::DateTime OPENFLUID_GetBeginDate() const;
 
@@ -150,11 +150,11 @@ class DLLEXPORT SimulationDrivenWare : public PluggableWare
     virtual void OPENFLUID_RaiseError(std::string Sender, std::string Source, std::string Msg);
 
 
+    SimulationDrivenWare(WareType WType) : PluggableWare(WType),
+        mp_SimStatus(NULL) { };
+
 
   public:
-
-    SimulationDrivenWare() : PluggableWare(),
-      mp_SimStatus(NULL) { };
 
     virtual ~SimulationDrivenWare() { };
 

--- a/src/openfluid/ware/SimulationInspectorWare.hpp
+++ b/src/openfluid/ware/SimulationInspectorWare.hpp
@@ -61,6 +61,7 @@
 #include <openfluid/core/CoreRepository.hpp>
 #include <openfluid/core/BooleanValue.hpp>
 #include <openfluid/core/MatrixValue.hpp>
+#include <openfluid/core/Datastore.hpp>
 
 
 namespace openfluid { namespace ware {
@@ -73,6 +74,10 @@ class DLLEXPORT SimulationInspectorWare : public SimulationDrivenWare
     static bool IsUnitIDInPtrList(const openfluid::core::UnitsPtrList_t* UnitsList,
                                   const openfluid::core::UnitID_t& ID);
 
+
+    openfluid::core::Datastore* mp_Datastore;
+
+
   protected:
 
     // TODO check if const
@@ -80,6 +85,9 @@ class DLLEXPORT SimulationInspectorWare : public SimulationDrivenWare
          Pointer to the core repository (const). It should be used with care. Prefer to use the OPENFLUID_Xxxx methods.
      */
     openfluid::core::CoreRepository* mp_CoreData;
+
+
+    virtual bool isLinked() const { return (SimulationDrivenWare::isLinked() && mp_CoreData != NULL && mp_Datastore != NULL); };
 
 
     /**
@@ -511,16 +519,22 @@ class DLLEXPORT SimulationInspectorWare : public SimulationDrivenWare
                                     const openfluid::core::UnitID_t& IDChild) const;
 
 
-  public:
+      SimulationInspectorWare(WareType WType) : SimulationDrivenWare(WType), mp_CoreData(NULL), mp_Datastore(NULL)
+      {};
 
-    SimulationInspectorWare() : SimulationDrivenWare(), mp_CoreData(NULL)
-    {};
+
+  public:
 
     virtual ~SimulationInspectorWare() {};
 
     void linkToCoreRepository(openfluid::core::CoreRepository* CoreRepos)
     {
       mp_CoreData = CoreRepos;
+    };
+
+    void linkToDatastore(openfluid::core::Datastore* DStore)
+    {
+      mp_Datastore = DStore;
     };
 
 };


### PR DESCRIPTION
wares
- Modified initialization hierarchy in wares
- Added datastore link in wares for future access during simulations
- Modified openfluid-engine strings

(references #8)
