### PR TITLE
Previous time index access for simulation functions and observers

### DIFF
--- a/resources/tests/datasets/OPENFLUID.IN.PrimitivesTime/model.fluidx
+++ b/resources/tests/datasets/OPENFLUID.IN.PrimitivesTime/model.fluidx
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone="yes"?>
+<openfluid>
+
+    <model>
+   
+      <function ID="tests.primitives.time" />                  
+    
+    </model>
+    
+</openfluid>

--- a/resources/tests/datasets/OPENFLUID.IN.PrimitivesTime/monitoring.fluidx
+++ b/resources/tests/datasets/OPENFLUID.IN.PrimitivesTime/monitoring.fluidx
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone="yes"?>
+<openfluid>
+
+  <monitoring>
+
+    <observer ID="tests.primitives.time" />
+
+  </monitoring>
+
+</openfluid>

--- a/resources/tests/datasets/OPENFLUID.IN.PrimitivesTime/run.fluidx
+++ b/resources/tests/datasets/OPENFLUID.IN.PrimitivesTime/run.fluidx
@@ -1,0 +1,7 @@
+<?xml version="1.0" standalone="yes"?>
+<openfluid>
+  <run>
+    <deltat>3600</deltat>
+    <period begin="2000-01-01 00:00:00" end="2000-01-01 06:00:00" />
+  </run>
+</openfluid>

--- a/resources/tests/datasets/OPENFLUID.IN.PrimitivesTime/testunits.ddata.fluidx
+++ b/resources/tests/datasets/OPENFLUID.IN.PrimitivesTime/testunits.ddata.fluidx
@@ -1,0 +1,26 @@
+<?xml version="1.0" standalone="yes"?>
+<openfluid>
+  <domain>
+    <inputdata unitclass="TestUnits">
+      <columns order="indataA;indataB;indataC" />
+      <data>
+
+1	1.1 CODE1 1.3
+2	1.1 CODE2 1.3
+3	1.1 CODE3 1.3
+4	1.1 CODE4 1.3
+5	1.1 CODE5 1.3
+6	1.1 CODE6 1.3
+7	1.1 CODE7 1.3
+8	1.1 CODE8 1.3
+9	1.1 CODE9 1.3
+10	1.1 CODE10 1.3
+11	1.1 CODE11 1.3
+12	1.1 CODE12 1.3
+
+      </data>
+    </inputdata>
+  </domain>
+</openfluid>
+
+

--- a/resources/tests/datasets/OPENFLUID.IN.PrimitivesTime/testunits.ddef.fluidx
+++ b/resources/tests/datasets/OPENFLUID.IN.PrimitivesTime/testunits.ddef.fluidx
@@ -1,0 +1,45 @@
+<?xml version="1.0" standalone="yes"?>
+<openfluid>
+  <domain>
+    <definition>
+      <unit class="ParentTestUnits" ID="1" pcsorder="1" />
+      <unit class="ParentTestUnits" ID="2" pcsorder="1" />
+
+      <unit class="TestUnits" ID="1" pcsorder="1">
+        <childof class="ParentTestUnits" ID="1" />
+      </unit>
+      <unit class="TestUnits" ID="2" pcsorder="2">
+        <childof class="ParentTestUnits" ID="2" />
+      </unit>
+      <unit class="TestUnits" ID="3" pcsorder="1">
+        <childof class="ParentTestUnits" ID="1" />
+      </unit>
+      <unit class="TestUnits" ID="4" pcsorder="3">
+        <childof class="ParentTestUnits" ID="2" />
+      </unit>
+      <unit class="TestUnits" ID="5" pcsorder="1">
+        <childof class="ParentTestUnits" ID="1" />
+      </unit>
+      <unit class="TestUnits" ID="6" pcsorder="2">
+        <childof class="ParentTestUnits" ID="2" />
+      </unit>
+      <unit class="TestUnits" ID="7" pcsorder="1">
+        <childof class="ParentTestUnits" ID="1" />
+      </unit>
+      <unit class="TestUnits" ID="8" pcsorder="2">
+        <childof class="ParentTestUnits" ID="2" />
+      </unit>
+      <unit class="TestUnits" ID="9" pcsorder="3">
+        <childof class="ParentTestUnits" ID="1" />
+      </unit>
+      <unit class="TestUnits" ID="10" pcsorder="2">
+      </unit>
+      <unit class="TestUnits" ID="11" pcsorder="4">
+      </unit>
+      <unit class="TestUnits" ID="12" pcsorder="1">
+      </unit>
+    </definition>
+  </domain>
+</openfluid>
+
+

--- a/src/openfluid/base/SimulationStatus.cpp
+++ b/src/openfluid/base/SimulationStatus.cpp
@@ -66,11 +66,11 @@ namespace openfluid { namespace base {
 
 SimulationStatus::SimulationStatus(const openfluid::core::DateTime& Begin,
                                    const openfluid::core::DateTime& End,
-                                   const Duration_t DeltaT)
+                                   const openfluid::core::Duration_t DeltaT)
 : m_BeginDate(Begin), m_EndDate(End), m_CurrentDate(Begin),
   m_CurrentTimeIndex(0), m_DefaultDeltaT(DeltaT),m_CurrentStage(PRE)
 {
-  m_Duration = Duration_t(End.diffInSeconds(Begin));
+  m_Duration = openfluid::core::Duration_t(End.diffInSeconds(Begin));
 }
 
 
@@ -78,7 +78,7 @@ SimulationStatus::SimulationStatus(const openfluid::core::DateTime& Begin,
 // =====================================================================
 
 
-void SimulationStatus::setCurrentTimeIndex(const TimeIndex_t& Index)
+void SimulationStatus::setCurrentTimeIndex(const openfluid::core::TimeIndex_t& Index)
 {
   if (m_CurrentStage != RUNSTEP)
     throw OFException("OpenFLUID framework","SimulationStatus::setCurrentTimeIndex()","Setting a time index is allowed during RUNSTEP stage only");

--- a/src/openfluid/base/SimulationStatus.hpp
+++ b/src/openfluid/base/SimulationStatus.hpp
@@ -68,15 +68,6 @@ namespace openfluid { namespace base {
 // =====================================================================
 
 
-typedef long long TimeIndex_t;
-
-typedef openfluid::core::RawTime_t Duration_t;
-
-
-// =====================================================================
-// =====================================================================
-
-
 class DLLEXPORT SimulationStatus
 {
   public:
@@ -90,13 +81,13 @@ class DLLEXPORT SimulationStatus
 
     openfluid::core::DateTime m_EndDate;
 
-    Duration_t m_Duration;
+    openfluid::core::Duration_t m_Duration;
 
     openfluid::core::DateTime m_CurrentDate;
 
-    TimeIndex_t m_CurrentTimeIndex;
+    openfluid::core::TimeIndex_t m_CurrentTimeIndex;
 
-    Duration_t m_DefaultDeltaT;
+    openfluid::core::Duration_t m_DefaultDeltaT;
 
     SimulationStage m_CurrentStage;
 
@@ -104,7 +95,7 @@ class DLLEXPORT SimulationStatus
 
     SimulationStatus(const openfluid::core::DateTime& Begin,
                      const openfluid::core::DateTime& End,
-                     const Duration_t DeltaT);
+                     const openfluid::core::Duration_t DeltaT);
 
     ~SimulationStatus() {}
 
@@ -114,15 +105,15 @@ class DLLEXPORT SimulationStatus
 
     inline openfluid::core::DateTime getCurrentDate() const { return m_CurrentDate; }
 
-    inline Duration_t getDefaultDeltaT() const { return m_DefaultDeltaT; }
+    inline openfluid::core::Duration_t getDefaultDeltaT() const { return m_DefaultDeltaT; }
 
-    inline Duration_t getSimulationDuration() const { return m_Duration; }
+    inline openfluid::core::Duration_t getSimulationDuration() const { return m_Duration; }
 
-    inline TimeIndex_t getCurrentTimeIndex() const { return m_CurrentTimeIndex; }
+    inline openfluid::core::TimeIndex_t getCurrentTimeIndex() const { return m_CurrentTimeIndex; }
 
     inline bool isFirstTimeIndex() const { return m_CurrentTimeIndex == 0; }
 
-    void setCurrentTimeIndex(const TimeIndex_t& Index);
+    void setCurrentTimeIndex(const openfluid::core::TimeIndex_t& Index);
 
     inline SimulationStage getCurrentStage() const { return m_CurrentStage; }
 

--- a/src/openfluid/machine/Engine.cpp
+++ b/src/openfluid/machine/Engine.cpp
@@ -741,7 +741,7 @@ void Engine::run()
     try
     {
       m_ModelInstance.processNextTimePoint();
-      m_MonitoringInstance.call_onStepCompleted();
+      m_MonitoringInstance.call_onStepCompleted(mp_SimStatus->getCurrentTimeIndex());
 
       // TODO to remove? check simulation vars production at each time step
       //checkSimulationVarsProduction(mp_SimStatus->getCurrentStep()+1);

--- a/src/openfluid/machine/ExecutionTimePoint.cpp
+++ b/src/openfluid/machine/ExecutionTimePoint.cpp
@@ -96,6 +96,7 @@ void ExecutionTimePoint::appendItem(openfluid::machine::ModelItemInstance* Item)
 openfluid::base::SchedulingRequest ExecutionTimePoint::processNextItem()
 {
   openfluid::base::SchedulingRequest SchedReq = m_ItemsPtrList.front()->Body->runStep();
+  m_ItemsPtrList.front()->Body->setPreviousTimeIndex(m_TimeIndex);
   m_ItemsPtrList.pop_front();
   return SchedReq;
 }

--- a/src/openfluid/machine/MonitoringInstance.cpp
+++ b/src/openfluid/machine/MonitoringInstance.cpp
@@ -217,7 +217,7 @@ void MonitoringInstance::call_onInitializedRun() const
 // =====================================================================
 
 
-void MonitoringInstance::call_onStepCompleted() const
+void MonitoringInstance::call_onStepCompleted(const openfluid::core::TimeIndex_t& TimeIndex) const
 {
   std::list<ObserverInstance*>::const_iterator ObsIter;
 
@@ -226,6 +226,7 @@ void MonitoringInstance::call_onStepCompleted() const
   while (ObsIter != m_Observers.end())
   {
     (*ObsIter)->Body->onStepCompleted();
+    (*ObsIter)->Body->setPreviousTimeIndex(TimeIndex);
     ObsIter++;
   }
 }

--- a/src/openfluid/machine/MonitoringInstance.hpp
+++ b/src/openfluid/machine/MonitoringInstance.hpp
@@ -98,7 +98,7 @@ class DLLEXPORT MonitoringInstance
 
     void call_onInitializedRun() const;
 
-    void call_onStepCompleted() const;
+    void call_onStepCompleted(const openfluid::core::TimeIndex_t& TimeIndex) const;
 
     void call_onFinalizedRun() const;
 };

--- a/src/openfluid/ware/SimulationDrivenWare.cpp
+++ b/src/openfluid/ware/SimulationDrivenWare.cpp
@@ -112,7 +112,7 @@ openfluid::core::DateTime SimulationDrivenWare::OPENFLUID_GetCurrentDate() const
 // =====================================================================
 
 
-openfluid::base::Duration_t SimulationDrivenWare::OPENFLUID_GetSimulationDuration() const
+openfluid::core::Duration_t SimulationDrivenWare::OPENFLUID_GetSimulationDuration() const
 {
   if (mp_SimStatus == NULL)
     throw openfluid::base::OFException("OpenFLUID framework","SimulationDrivenWare::OPENFLUID_GetSimulationDuration()","Simulation status is not set");
@@ -125,7 +125,7 @@ openfluid::base::Duration_t SimulationDrivenWare::OPENFLUID_GetSimulationDuratio
 // =====================================================================
 
 
-openfluid::base::Duration_t SimulationDrivenWare::OPENFLUID_GetDefaultDeltaT() const
+openfluid::core::Duration_t SimulationDrivenWare::OPENFLUID_GetDefaultDeltaT() const
 {
   if (mp_SimStatus == NULL)
     throw openfluid::base::OFException("OpenFLUID framework","SimulationDrivenWare::OPENFLUID_GetDefaultDeltaT()","Simulation status is not set");
@@ -138,12 +138,29 @@ openfluid::base::Duration_t SimulationDrivenWare::OPENFLUID_GetDefaultDeltaT() c
 // =====================================================================
 
 
-openfluid::base::TimeIndex_t SimulationDrivenWare::OPENFLUID_GetCurrentTimeIndex() const
+openfluid::core::TimeIndex_t SimulationDrivenWare::OPENFLUID_GetCurrentTimeIndex() const
 {
   if (mp_SimStatus == NULL)
     throw openfluid::base::OFException("OpenFLUID framework","SimulationDrivenWare::OPENFLUID_GetCurrentTimeIndex()","Simulation status is not set");
 
   return mp_SimStatus->getCurrentTimeIndex();
+}
+
+
+// =====================================================================
+// =====================================================================
+
+
+openfluid::core::TimeIndex_t SimulationDrivenWare::OPENFLUID_GetPreviousRunTimeIndex() const
+{
+  REQUIRE_SIMULATION_STAGE_GE(openfluid::base::SimulationStatus::RUNSTEP,
+                           "SimulationDrivenWare::OPENFLUID_GetPreviousRunTimeIndex",
+                           "Previous run time index cannot be accessed outside RUNSTEP or FINALIZERUN stages");
+
+  if (mp_SimStatus == NULL)
+    throw openfluid::base::OFException("OpenFLUID framework","SimulationDrivenWare::OPENFLUID_GetPreviousRunTimeIndex()","Simulation status is not set");
+
+  return m_PreviousTimeIndex;
 }
 
 

--- a/src/openfluid/ware/SimulationDrivenWare.hpp
+++ b/src/openfluid/ware/SimulationDrivenWare.hpp
@@ -85,6 +85,8 @@ class DLLEXPORT SimulationDrivenWare : public PluggableWare
 
     const openfluid::base::SimulationStatus* mp_SimStatus;
 
+    openfluid::core::TimeIndex_t m_PreviousTimeIndex;
+
 
   protected:
 
@@ -96,11 +98,13 @@ class DLLEXPORT SimulationDrivenWare : public PluggableWare
 
     openfluid::core::DateTime OPENFLUID_GetCurrentDate() const;
 
-    openfluid::base::Duration_t OPENFLUID_GetSimulationDuration() const;
+    openfluid::core::Duration_t OPENFLUID_GetSimulationDuration() const;
 
-    openfluid::base::Duration_t OPENFLUID_GetDefaultDeltaT() const;
+    openfluid::core::Duration_t OPENFLUID_GetDefaultDeltaT() const;
 
-    openfluid::base::TimeIndex_t OPENFLUID_GetCurrentTimeIndex() const;
+    openfluid::core::TimeIndex_t OPENFLUID_GetCurrentTimeIndex() const;
+
+    openfluid::core::TimeIndex_t OPENFLUID_GetPreviousRunTimeIndex() const;
 
     openfluid::base::SimulationStatus::SimulationStage OPENFLUID_GetCurrentStage() const;
 
@@ -137,7 +141,7 @@ class DLLEXPORT SimulationDrivenWare : public PluggableWare
 
 
     SimulationDrivenWare(WareType WType) : PluggableWare(WType),
-        mp_SimStatus(NULL) { };
+        mp_SimStatus(NULL), m_PreviousTimeIndex(0) { };
 
 
   public:
@@ -145,6 +149,8 @@ class DLLEXPORT SimulationDrivenWare : public PluggableWare
     virtual ~SimulationDrivenWare() { };
 
     void linkToSimulation(const openfluid::base::SimulationStatus* SimStatus);
+
+    void setPreviousTimeIndex(const openfluid::core::TimeIndex_t& TimeIndex) { m_PreviousTimeIndex = TimeIndex; };
 
 };
 

--- a/src/tests/functions/CMakeLists.txt
+++ b/src/tests/functions/CMakeLists.txt
@@ -35,6 +35,22 @@ ENDIF(BUILD_FORTRAN_FUNCTIONS)
 ###########################################################################
 
 
+OPNFLD_ADD_FUNCTION(tests.primitives.time tests.primitives.time ${TEST_OUTPUT_PATH})
+OPENFLUID_ADD_TEST(NAME functions-PrimitivesTime 
+                   COMMAND "${BIN_OUTPUT_PATH}/${OPENFLUID_CMD_APP}" 
+                           "-i${TESTS_DATASETS_PATH}/OPENFLUID.IN.PrimitivesTime"
+                           "-o${TESTS_OUTPUTDATA_PATH}/OPENFLUID.OUT.PrimitivesTime" 
+                           "-p${TEST_OUTPUT_PATH}"
+                           "-n${TEST_OUTPUT_PATH}"
+                    PRE_TEST REMOVE_DIRECTORY "${TESTS_OUTPUTDATA_PATH}/OPENFLUID.OUT.PrimitivesTime"
+                    POST_TEST CHECK_FILE_EXIST "${TESTS_OUTPUTDATA_PATH}/OPENFLUID.OUT.PrimitivesTime/openfluid-messages.log"
+                              CHECK_FILE_EXIST "${TESTS_OUTPUTDATA_PATH}/OPENFLUID.OUT.PrimitivesTime/tests.primitives.time_ofware-func.log"
+                              CHECK_FILE_EXIST "${TESTS_OUTPUTDATA_PATH}/OPENFLUID.OUT.PrimitivesTime/tests.primitives.time_ofware-obs.log"
+                   )
+
+###########################################################################
+
+
 OPNFLD_ADD_FUNCTION(tests.primitives.prod tests.primitives.prod ${TEST_OUTPUT_PATH})
 OPNFLD_ADD_FUNCTION(tests.primitives.use tests.primitives.use ${TEST_OUTPUT_PATH})
 

--- a/src/tests/functions/tests.primitives.time/TimePrimitivesFunc.cpp
+++ b/src/tests/functions/tests.primitives.time/TimePrimitivesFunc.cpp
@@ -1,0 +1,234 @@
+/*
+  This file is part of OpenFLUID software
+  Copyright (c) 2007-2010 INRA-Montpellier SupAgro
+
+
+ == GNU General Public License Usage ==
+
+  OpenFLUID is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OpenFLUID is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OpenFLUID.  If not, see <http://www.gnu.org/licenses/>.
+
+  In addition, as a special exception, INRA gives You the additional right
+  to dynamically link the code of OpenFLUID with code not covered
+  under the GNU General Public License ("Non-GPL Code") and to distribute
+  linked combinations including the two, subject to the limitations in this
+  paragraph. Non-GPL Code permitted under this exception must only link to
+  the code of OpenFLUID dynamically through the OpenFLUID libraries
+  interfaces, and only for building OpenFLUID plugins. The files of
+  Non-GPL Code may be link to the OpenFLUID libraries without causing the
+  resulting work to be covered by the GNU General Public License. You must
+  obey the GNU General Public License in all respects for all of the
+  OpenFLUID code and other code used in conjunction with OpenFLUID
+  except the Non-GPL Code covered by this exception. If you modify
+  this OpenFLUID, you may extend this exception to your version of the file,
+  but you are not obligated to do so. If you do not wish to provide this
+  exception without modification, you must delete this exception statement
+  from your version and license this OpenFLUID solely under the GPL without
+  exception.
+
+
+ == Other Usage ==
+
+  Other Usage means a use of OpenFLUID that is inconsistent with the GPL
+  license, and requires a written agreement between You and INRA.
+  Licensees for Other Usage of OpenFLUID may use this file in accordance
+  with the terms contained in the written agreement between You and INRA.
+*/
+
+
+/**
+  \file TimePrimitivesFunc.cpp
+  \brief Implements ...
+
+  \author Jean-Christophe FABRE <fabrejc@supagro.inra.fr>
+ */
+
+
+#include <openfluid/ware/PluggableFunction.hpp>
+
+
+// =====================================================================
+// =====================================================================
+
+
+DECLARE_FUNCTION_PLUGIN
+
+
+BEGIN_FUNCTION_SIGNATURE("tests.primitives.time")
+
+  DECLARE_SIGNATURE_NAME("");
+  DECLARE_SIGNATURE_DESCRIPTION("");
+
+  DECLARE_SIGNATURE_VERSION("1.0");
+  DECLARE_SIGNATURE_SDKVERSION;
+  DECLARE_SIGNATURE_STATUS(openfluid::ware::EXPERIMENTAL);
+
+  DECLARE_SIGNATURE_DOMAIN("");
+  DECLARE_SIGNATURE_PROCESS("");
+  DECLARE_SIGNATURE_METHOD("");
+  DECLARE_SIGNATURE_AUTHORNAME("");
+  DECLARE_SIGNATURE_AUTHOREMAIL("");
+
+  DECLARE_SCHEDULING_DEFAULT();
+
+END_FUNCTION_SIGNATURE
+
+
+// =====================================================================
+// =====================================================================
+
+
+class TimePrimitivesFunction : public openfluid::ware::PluggableFunction
+{
+  private:
+
+    bool m_IsFirstRunStep;
+
+  public:
+
+
+    TimePrimitivesFunction() : PluggableFunction(), m_IsFirstRunStep(true)
+    {
+
+
+    }
+
+
+    // =====================================================================
+    // =====================================================================
+
+
+    ~TimePrimitivesFunction()
+    {
+
+
+    }
+
+
+    // =====================================================================
+    // =====================================================================
+
+
+    void initParams(const openfluid::ware::WareParams_t& /*Params*/)
+    {
+      if (OPENFLUID_GetCurrentStage() != openfluid::base::SimulationStatus::INITPARAMS)
+        OPENFLUID_RaiseError("tests.primitives.time","initParams()","wrong stage");
+    }
+
+    // =====================================================================
+    // =====================================================================
+
+
+    void prepareData()
+    {
+      if (OPENFLUID_GetCurrentStage() != openfluid::base::SimulationStatus::PREPAREDATA)
+        OPENFLUID_RaiseError("tests.primitives.time","prepareData()","prepare data");
+
+      if (OPENFLUID_GetBeginDate() != openfluid::core::DateTime(2000,1,1,0,0,0))
+        OPENFLUID_RaiseError("tests.primitives.time","prepareData()","wrong begin date");
+
+      if (OPENFLUID_GetEndDate() != openfluid::core::DateTime(2000,1,1,6,0,0))
+        OPENFLUID_RaiseError("tests.primitives.time","prepareData()","wrong end date");
+
+      if (OPENFLUID_GetSimulationDuration() != 21600)
+        OPENFLUID_RaiseError("tests.primitives.time","prepareData()","wrong simulation duration");
+
+      if (OPENFLUID_GetDefaultDeltaT() != 3600)
+        OPENFLUID_RaiseError("tests.primitives.time","prepareData()","wrong default deltaT");
+
+    }
+
+
+    // =====================================================================
+    // =====================================================================
+
+
+    void checkConsistency()
+    {
+      if (OPENFLUID_GetCurrentStage() != openfluid::base::SimulationStatus::CHECKCONSISTENCY)
+        OPENFLUID_RaiseError("tests.primitives.time","checkConsistency()","wrong stage");
+    }
+
+
+    // =====================================================================
+    // =====================================================================
+
+
+    openfluid::base::SchedulingRequest initializeRun()
+    {
+      if (OPENFLUID_GetCurrentStage() != openfluid::base::SimulationStatus::INITIALIZERUN)
+        OPENFLUID_RaiseError("tests.primitives.time","initializeRun()","wrong stage");
+
+      if (OPENFLUID_GetCurrentDate() != OPENFLUID_GetBeginDate())
+        OPENFLUID_RaiseError("tests.primitives.time","initializeRun()","wrong current date");
+
+      return DefaultDeltaT();
+    }
+
+
+    // =====================================================================
+    // =====================================================================
+
+
+    openfluid::base::SchedulingRequest runStep()
+    {
+      if (OPENFLUID_GetCurrentStage() != openfluid::base::SimulationStatus::RUNSTEP)
+        OPENFLUID_RaiseError("tests.primitives.time","runStep()","wrong stage");
+
+
+      if (m_IsFirstRunStep)
+      {
+        m_IsFirstRunStep = false;
+
+        if (OPENFLUID_GetCurrentTimeIndex() != OPENFLUID_GetDefaultDeltaT())
+          OPENFLUID_RaiseError("tests.primitives.time","runStep()","wrong time index");
+
+        if (OPENFLUID_GetPreviousRunTimeIndex() != 0)
+          OPENFLUID_RaiseError("tests.primitives.time","runStep()","wrong previous run time index");
+      }
+      else
+      {
+        if (OPENFLUID_GetPreviousRunTimeIndex() != (OPENFLUID_GetCurrentTimeIndex()-47))
+          OPENFLUID_RaiseError("tests.primitives.time","runStep()","wrong previous run time index");
+
+        if ((OPENFLUID_GetCurrentTimeIndex()-OPENFLUID_GetDefaultDeltaT()) % 47 != 0 )
+          OPENFLUID_RaiseError("tests.primitives.time","runStep()","wrong time index");
+
+      }
+
+      if (OPENFLUID_GetCurrentDate() != (OPENFLUID_GetBeginDate()+OPENFLUID_GetCurrentTimeIndex()))
+        OPENFLUID_RaiseError("tests.primitives.time","runStep()","wrong current date");
+
+
+      return Duration(47);
+    }
+
+    // =====================================================================
+    // =====================================================================
+
+
+    void finalizeRun()
+    {
+      if (OPENFLUID_GetCurrentStage() != openfluid::base::SimulationStatus::FINALIZERUN)
+        OPENFLUID_RaiseError("tests.primitives.time","finalizeRun()","wrong stage");
+    }
+
+};
+
+
+// =====================================================================
+// =====================================================================
+
+
+DEFINE_FUNCTION_CLASS(TimePrimitivesFunction)
+

--- a/src/tests/observers/CMakeLists.txt
+++ b/src/tests/observers/CMakeLists.txt
@@ -8,7 +8,7 @@ INCLUDE_DIRECTORIES("${PROJECT_SOURCE_DIR}/src" "${PROJECT_BINARY_DIR}/src")
 
 
 OPNFLD_ADD_OBSERVER(tests.empty tests.empty ${TEST_OUTPUT_PATH})
-
+OPNFLD_ADD_OBSERVER(tests.primitives.time tests.primitives.time ${TEST_OUTPUT_PATH})
 
 ###########################################################################
 

--- a/src/tests/observers/tests.primitives.time/TimePrimitivesObs.cpp
+++ b/src/tests/observers/tests.primitives.time/TimePrimitivesObs.cpp
@@ -1,0 +1,201 @@
+/*
+  This file is part of OpenFLUID software
+  Copyright (c) 2007-2010 INRA-Montpellier SupAgro
+
+
+ == GNU General Public License Usage ==
+
+  OpenFLUID is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OpenFLUID is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OpenFLUID.  If not, see <http://www.gnu.org/licenses/>.
+
+  In addition, as a special exception, INRA gives You the additional right
+  to dynamically link the code of OpenFLUID with code not covered
+  under the GNU General Public License ("Non-GPL Code") and to distribute
+  linked combinations including the two, subject to the limitations in this
+  paragraph. Non-GPL Code permitted under this exception must only link to
+  the code of OpenFLUID dynamically through the OpenFLUID libraries
+  interfaces, and only for building OpenFLUID plugins. The files of
+  Non-GPL Code may be link to the OpenFLUID libraries without causing the
+  resulting work to be covered by the GNU General Public License. You must
+  obey the GNU General Public License in all respects for all of the
+  OpenFLUID code and other code used in conjunction with OpenFLUID
+  except the Non-GPL Code covered by this exception. If you modify
+  this OpenFLUID, you may extend this exception to your version of the file,
+  but you are not obligated to do so. If you do not wish to provide this
+  exception without modification, you must delete this exception statement
+  from your version and license this OpenFLUID solely under the GPL without
+  exception.
+
+
+ == Other Usage ==
+
+  Other Usage means a use of OpenFLUID that is inconsistent with the GPL
+  license, and requires a written agreement between You and INRA.
+  Licensees for Other Usage of OpenFLUID may use this file in accordance
+  with the terms contained in the written agreement between You and INRA.
+*/
+
+
+/**
+  \file TimePrimitivesObs.cpp
+  \brief Implements ...
+
+  \author Jean-Christophe FABRE <fabrejc@supagro.inra.fr>
+ */
+
+
+#include <openfluid/ware/PluggableObserver.hpp>
+
+
+// =====================================================================
+// =====================================================================
+
+
+DECLARE_OBSERVER_PLUGIN
+
+
+// =====================================================================
+// =====================================================================
+
+
+BEGIN_OBSERVER_SIGNATURE("tests.primitives.time")
+
+  DECLARE_SIGNATURE_NAME("");
+  DECLARE_SIGNATURE_DESCRIPTION("");
+
+  DECLARE_SIGNATURE_VERSION("1.0");
+  DECLARE_SIGNATURE_STATUS(openfluid::ware::EXPERIMENTAL);
+
+END_FUNCTION_SIGNATURE
+
+
+// =====================================================================
+// =====================================================================
+
+
+class TimePrimitivesObserver : public openfluid::ware::PluggableObserver
+{
+
+  private:
+
+    bool m_IsFirstRunStep;
+
+
+  public:
+
+    TimePrimitivesObserver() : PluggableObserver(), m_IsFirstRunStep(true)
+    {
+
+    }
+
+    // =====================================================================
+    // =====================================================================
+
+
+    ~TimePrimitivesObserver()
+    {
+
+    }
+
+
+    // =====================================================================
+    // =====================================================================
+
+
+    void initParams(const openfluid::ware::WareParams_t& /*Params*/)
+    {
+
+    }
+
+
+    // =====================================================================
+    // =====================================================================
+
+
+    void onPrepared()
+    {
+
+    }
+
+
+    // =====================================================================
+    // =====================================================================
+
+
+    void onInitializedRun()
+    {
+      if (OPENFLUID_GetCurrentStage() != openfluid::base::SimulationStatus::INITIALIZERUN)
+        OPENFLUID_RaiseError("tests.primitives.time","onInitializedRun()","wrong stage");
+
+      if (OPENFLUID_GetCurrentDate() != OPENFLUID_GetBeginDate())
+        OPENFLUID_RaiseError("tests.primitives.time","onInitializedRun()","wrong current date");
+
+    }
+
+
+    // =====================================================================
+    // =====================================================================
+
+
+    void onStepCompleted()
+    {
+      if (OPENFLUID_GetCurrentStage() != openfluid::base::SimulationStatus::RUNSTEP)
+        OPENFLUID_RaiseError("tests.primitives.time","onStepCompleted()","wrong stage");
+
+
+      if (m_IsFirstRunStep)
+      {
+        m_IsFirstRunStep = false;
+
+        if (OPENFLUID_GetCurrentTimeIndex() != OPENFLUID_GetDefaultDeltaT())
+          OPENFLUID_RaiseError("tests.primitives.time","onStepCompleted()","wrong time index");
+
+        if (OPENFLUID_GetPreviousRunTimeIndex() != 0)
+          OPENFLUID_RaiseError("tests.primitives.time","onStepCompleted()","wrong previous run time index");
+      }
+      else
+      {
+        if (OPENFLUID_GetPreviousRunTimeIndex() != (OPENFLUID_GetCurrentTimeIndex()-47))
+          OPENFLUID_RaiseError("tests.primitives.time","onStepCompleted()","wrong previous run time index");
+
+        if ((OPENFLUID_GetCurrentTimeIndex()-OPENFLUID_GetDefaultDeltaT()) % 47 != 0 )
+          OPENFLUID_RaiseError("tests.primitives.time","onStepCompleted()","wrong time index");
+
+      }
+
+      if (OPENFLUID_GetCurrentDate() != (OPENFLUID_GetBeginDate()+OPENFLUID_GetCurrentTimeIndex()))
+        OPENFLUID_RaiseError("tests.primitives.time","onStepCompleted()","wrong current date");
+    }
+
+
+    // =====================================================================
+    // =====================================================================
+
+
+    void onFinalizedRun()
+    {
+      if (OPENFLUID_GetCurrentStage() != openfluid::base::SimulationStatus::FINALIZERUN)
+        OPENFLUID_RaiseError("tests.primitives.time","finalizeRun()","wrong stage");
+
+    }
+
+
+};
+
+
+// =====================================================================
+// =====================================================================
+
+
+DEFINE_OBSERVER_CLASS(TimePrimitivesObserver)
+


### PR DESCRIPTION
- Added OPENFLUID_GetPreviousRunTimeIndex() primitive
- Adapted simulation engine to provide previous run information
  to wares
- Updated tests for time primitives
- Cleaned time and durations types definitions

(closes #71)
