### PR TITLE
Removal of constraints on required variables at a previous time step

### DIFF
--- a/examples/functions/examples.primitives.unitsA.prod/ExampleUnitsAProd.cpp
+++ b/examples/functions/examples.primitives.unitsA.prod/ExampleUnitsAProd.cpp
@@ -32,7 +32,7 @@ BEGIN_FUNCTION_SIGNATURE("examples.primitives.unitsA.prod")
   DECLARE_SIGNATURE_AUTHORNAME("Jean-Christophe Fabre");
   DECLARE_SIGNATURE_AUTHOREMAIL("fabrejc@supagro.inra.fr");
 
-  DECLARE_REQUIRED_PREVVAR("var3","unitsA","the variable 3","");
+  DECLARE_REQUIRED_VAR("var3","unitsA","the variable 3","");
   
   DECLARE_PRODUCED_VAR("var1","unitsA","the variable 1","");
   DECLARE_PRODUCED_VAR("var2","unitsA","the variable 2","");

--- a/src/apps/openfluid-builder/builder-main/model/SignatureDetailWidget.cpp
+++ b/src/apps/openfluid-builder/builder-main/model/SignatureDetailWidget.cpp
@@ -170,10 +170,7 @@ void SignatureDetailWidget::update(
   updateVarsModel(Signature->Signature->HandledData.RequiredVars,
                   _("Required"));
   updateVarsModel(Signature->Signature->HandledData.UsedVars, _("Used"));
-  updateVarsModel(Signature->Signature->HandledData.RequiredPrevVars,
-                  _("Required t-1"));
-  updateVarsModel(Signature->Signature->HandledData.UsedPrevVars,
-                  _("Used t-1"));
+
   if (!mref_VarsModel->children().empty())
     append_page(*mp_VarsWin, _("Variables"));
   mp_VarsTreeView->expand_all();

--- a/src/apps/openfluid/OpenFLUID.cpp
+++ b/src/apps/openfluid/OpenFLUID.cpp
@@ -252,9 +252,7 @@ void OpenFLUIDApp::printFunctionsHandledDataItemReport(openfluid::ware::Signatur
   if (Type == ("uvar")) TypeStr = ("updated variable");
 
   if (Type == ("rvar")) TypeStr = ("required variable");
-  if (Type == ("rprevvar")) TypeStr = ("required variable produced at previous step");
   if (Type == ("svar")) TypeStr = ("used variable (only if available)");
-  if (Type == ("sprevvar")) TypeStr = ("used variable produced at previous step (only if available)");
 
   if (Type == ("fpar")) TypeStr = ("function parameter");
 
@@ -326,8 +324,6 @@ void OpenFLUIDApp::printFunctionsHandledDataReport(openfluid::ware::SignatureHan
   for (i=0;i<HandledData.RequiredVars.size();i++) printFunctionsHandledDataItemReport(HandledData.RequiredVars[i],Suffix,("rvar"));
   for (i=0;i<HandledData.UpdatedVars.size();i++) printFunctionsHandledDataItemReport(HandledData.UpdatedVars[i],Suffix,("uvar"));
   for (i=0;i<HandledData.UsedVars.size();i++) printFunctionsHandledDataItemReport(HandledData.UsedVars[i],Suffix,("svar"));
-  for (i=0;i<HandledData.RequiredPrevVars.size();i++) printFunctionsHandledDataItemReport(HandledData.RequiredPrevVars[i],Suffix,("rprevvar"));
-  for (i=0;i<HandledData.UsedPrevVars.size();i++) printFunctionsHandledDataItemReport(HandledData.UsedPrevVars[i],Suffix,("sprevvar"));
   for (i=0;i<HandledData.ProducedInputdata.size();i++) printFunctionsHandledDataItemReport(HandledData.ProducedInputdata[i],Suffix,("pinput"));
   for (i=0;i<HandledData.RequiredInputdata.size();i++) printFunctionsHandledDataItemReport(HandledData.RequiredInputdata[i],Suffix,("rinput"));
   for (i=0;i<HandledData.UsedInputdata.size();i++) printFunctionsHandledDataItemReport(HandledData.UsedInputdata[i],Suffix,("sinput"));

--- a/src/openfluid/machine/Engine.hpp
+++ b/src/openfluid/machine/Engine.hpp
@@ -90,24 +90,6 @@ class SimulationBlob;
 */
 class DLLEXPORT Engine
 {
-  public:
-
-    struct PretestInfos_t
-    {
-      bool Model;
-      std::string ModelMsg;
-
-      bool Inputdata;
-      std::string InputdataMsg;
-
-      bool ExtraFiles;
-      std::string ExtraFilesMsg;
-
-      PretestInfos_t() : Model(true), ModelMsg(""),
-          Inputdata(true), InputdataMsg(""),
-          ExtraFiles(true), ExtraFilesMsg("")
-        { };
-    };
 
   private:
 
@@ -170,8 +152,6 @@ class DLLEXPORT Engine
     */
     ~Engine();
 
-
-    void pretestConsistency(PretestInfos_t& PretestInfos);
 
     void initialize();
 

--- a/src/openfluid/machine/tests/Engine_TEST.cpp
+++ b/src/openfluid/machine/tests/Engine_TEST.cpp
@@ -109,18 +109,6 @@ void displayModel(openfluid::machine::ModelInstance& MI)
 // =====================================================================
 
 
-void displayPretestsMsgs(const openfluid::machine::Engine::PretestInfos_t& PInfos)
-{
-  if (!PInfos.ExtraFilesMsg.empty()) std::cout << PInfos.ExtraFilesMsg << std::endl;
-  if (!PInfos.InputdataMsg.empty()) std::cout << PInfos.InputdataMsg << std::endl;
-  if (!PInfos.ModelMsg.empty()) std::cout << PInfos.ModelMsg << std::endl;
-}
-
-
-// =====================================================================
-// =====================================================================
-
-
 BOOST_AUTO_TEST_CASE(check_construction)
 {
   openfluid::machine::SimulationBlob SBlob;
@@ -156,18 +144,7 @@ BOOST_AUTO_TEST_CASE(check_pretests)
 
   openfluid::machine::Engine Eng(SBlob,Model,Monitoring,MachineListen);
 
-  openfluid::machine::Engine::PretestInfos_t PInfos;
-
-  PInfos.ExtraFiles = true;
-  PInfos.Inputdata = true;
-  PInfos.Model = true;
-
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,true);
 
   // =====================================================================
 
@@ -185,12 +162,6 @@ BOOST_AUTO_TEST_CASE(check_pretests)
   Model.appendItem(MIInstance);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,false);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
 
   // =====================================================================
 
@@ -206,12 +177,6 @@ BOOST_AUTO_TEST_CASE(check_pretests)
   Model.insertItem(MIInstance,0);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,true);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
 
   // =====================================================================
 
@@ -226,12 +191,6 @@ BOOST_AUTO_TEST_CASE(check_pretests)
   Model.appendItem(MIInstance);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,true);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
 
 
   // =====================================================================
@@ -242,18 +201,11 @@ BOOST_AUTO_TEST_CASE(check_pretests)
   MIInstance->Signature = new openfluid::ware::FunctionSignature();
   MIInstance->Signature->ID = "MyFunc0.5";
   MIInstance->Signature->HandledData.RequiredVars.push_back(openfluid::ware::SignatureHandledTypedDataItem("var1","UA","",""));
-  MIInstance->Signature->HandledData.RequiredPrevVars.push_back(openfluid::ware::SignatureHandledTypedDataItem("var5[]","UB","",""));
 
   Model.resetInitialized();
   Model.insertItem(MIInstance,1);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,true);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
 
 
   // =====================================================================
@@ -263,18 +215,11 @@ BOOST_AUTO_TEST_CASE(check_pretests)
   MIInstance->Verified = true;
   MIInstance->Signature = new openfluid::ware::FunctionSignature();
   MIInstance->Signature->ID = "MyFunc3";
-  MIInstance->Signature->HandledData.RequiredPrevVars.push_back(openfluid::ware::SignatureHandledTypedDataItem("var7","UC","",""));
 
   Model.resetInitialized();
   Model.appendItem(MIInstance);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,false);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
 
   // =====================================================================
 
@@ -291,13 +236,6 @@ BOOST_AUTO_TEST_CASE(check_pretests)
   Model.appendItem(MIInstance);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,true);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
-
 
 
   delete MachineListen;
@@ -321,18 +259,8 @@ BOOST_AUTO_TEST_CASE(check_typed_pretests)
 
   openfluid::machine::Engine Eng(SBlob,Model,Monitoring,MachineListen);
 
-  openfluid::machine::Engine::PretestInfos_t PInfos;
-
-  PInfos.ExtraFiles = true;
-  PInfos.Inputdata = true;
-  PInfos.Model = true;
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,true);
 
   // =====================================================================
 
@@ -350,12 +278,6 @@ BOOST_AUTO_TEST_CASE(check_typed_pretests)
   Model.appendItem(MIInstance);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,false);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
 
   // =====================================================================
 
@@ -371,12 +293,6 @@ BOOST_AUTO_TEST_CASE(check_typed_pretests)
   Model.insertItem(MIInstance,0);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,true);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
 
   // =====================================================================
 
@@ -391,12 +307,6 @@ BOOST_AUTO_TEST_CASE(check_typed_pretests)
   Model.appendItem(MIInstance);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,true);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
 
 
   // =====================================================================
@@ -407,18 +317,11 @@ BOOST_AUTO_TEST_CASE(check_typed_pretests)
   MIInstance->Signature = new openfluid::ware::FunctionSignature();
   MIInstance->Signature->ID = "MyFunc0.5";
   MIInstance->Signature->HandledData.RequiredVars.push_back(openfluid::ware::SignatureHandledTypedDataItem("var1","UA","",""));
-  MIInstance->Signature->HandledData.RequiredPrevVars.push_back(openfluid::ware::SignatureHandledTypedDataItem("var5[]","UB","",""));
 
   Model.resetInitialized();
   Model.insertItem(MIInstance,1);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,true);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
 
 
   // =====================================================================
@@ -428,18 +331,11 @@ BOOST_AUTO_TEST_CASE(check_typed_pretests)
   MIInstance->Verified = true;
   MIInstance->Signature = new openfluid::ware::FunctionSignature();
   MIInstance->Signature->ID = "MyFunc3";
-  MIInstance->Signature->HandledData.RequiredPrevVars.push_back(openfluid::ware::SignatureHandledTypedDataItem("var7[double]","UC","",""));
 
   Model.resetInitialized();
   Model.appendItem(MIInstance);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,false);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
 
   // =====================================================================
 
@@ -456,12 +352,6 @@ BOOST_AUTO_TEST_CASE(check_typed_pretests)
   Model.appendItem(MIInstance);
 
   displayModel(Model);
-  Eng.pretestConsistency(PInfos);
-  displayPretestsMsgs(PInfos);
-  BOOST_REQUIRE_EQUAL(PInfos.ExtraFiles,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Inputdata,true);
-  BOOST_REQUIRE_EQUAL(PInfos.Model,false);
-  PInfos = openfluid::machine::Engine::PretestInfos_t();
 
 
 

--- a/src/openfluid/machine/tests/FunctionSignatureRegistry_TEST.cpp
+++ b/src/openfluid/machine/tests/FunctionSignatureRegistry_TEST.cpp
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(test_constructor)
 
   BOOST_CHECK_EQUAL(
       Signatures->getFctSignatures()[openfluid::fluidx::ModelItemDescriptor::PluggedFunction].size(),
-      3);
+      5);
   BOOST_CHECK_EQUAL(
       Signatures->getFctSignatures()[openfluid::fluidx::ModelItemDescriptor::Generator].size(),
       4);

--- a/src/openfluid/ware/FunctionSignature.hpp
+++ b/src/openfluid/ware/FunctionSignature.hpp
@@ -157,17 +157,6 @@
   Signature->HandledData.RequiredVars.push_back(openfluid::ware::SignatureHandledTypedDataItem((name),uclass,description,unit));
 
 
-
-/**
-  Macro for declaration of a required variable, using a value produced on a previous time step
-  @param[in] name name of the variable
-  @param[in] uclass class of the concerned units
-  @param[in] description description of the variable
-  @param[in] unit unit of the variable. Could be an empty string if there is no unit
-*/
-#define DECLARE_REQUIRED_PREVVAR(name,uclass,description,unit) \
-  Signature->HandledData.RequiredPrevVars.push_back(openfluid::ware::SignatureHandledTypedDataItem((name),uclass,description,unit));
-
 /**
   Macro for declaration of an used variable
   @param[in] name name of the variable
@@ -178,16 +167,6 @@
 #define DECLARE_USED_VAR(name,uclass,description,unit) \
   Signature->HandledData.UsedVars.push_back(openfluid::ware::SignatureHandledTypedDataItem((name),uclass,description,unit));
 
-
-/**
-  Macro for declaration of an used variable, using a value produced on a previous time step
-  @param[in] name name of the variable
-  @param[in] uclass class of the concerned units
-  @param[in] description description of the variable
-  @param[in] unit unit of the variable. Could be an empty string if there is no unit
-*/
-#define DECLARE_USED_PREVVAR(name,uclass,description,unit) \
-  Signature->HandledData.UsedPrevVars.push_back(openfluid::ware::SignatureHandledTypedDataItem((name),uclass,description,unit));
 
 /**
   Macro for declaration of a produced input data
@@ -416,10 +395,6 @@ class SignatureHandledData
     std::vector<SignatureHandledTypedDataItem> RequiredVars;
 
     std::vector<SignatureHandledTypedDataItem> UsedVars;
-
-    std::vector<SignatureHandledTypedDataItem> RequiredPrevVars;
-
-    std::vector<SignatureHandledTypedDataItem> UsedPrevVars;
 
     std::vector<SignatureHandledDataItem> FunctionParams;
 

--- a/src/openfluid/ware/tests/FunctionSignature_TEST.cpp
+++ b/src/openfluid/ware/tests/FunctionSignature_TEST.cpp
@@ -117,10 +117,6 @@ BOOST_AUTO_TEST_CASE(check_operations)
   DECLARE_USED_VAR("uvar1","UnitClassA","this is uvar1","s");
   DECLARE_USED_VAR("uvar2","UnitClassA","this is uvar2","s-1");
 
-  DECLARE_REQUIRED_PREVVAR("rvar1prev","UnitClassA","this is rvar1prev","mm/h");
-
-  DECLARE_USED_PREVVAR("uvar1prev","UnitClassA","this is uvar1prev","mm/h");
-
   DECLARE_USED_EVENTS("UnitClassA");
   DECLARE_USED_EVENTS("UnitClassB");
 
@@ -166,10 +162,6 @@ BOOST_AUTO_TEST_CASE(check_operations)
   BOOST_REQUIRE_EQUAL(Signature->HandledData.UpdatedVars.size(),1);
 
   BOOST_REQUIRE_EQUAL(Signature->HandledData.UsedVars.size(),2);
-
-  BOOST_REQUIRE_EQUAL(Signature->HandledData.RequiredPrevVars.size(),1);
-
-  BOOST_REQUIRE_EQUAL(Signature->HandledData.UsedPrevVars.size(),1);
 
   BOOST_REQUIRE_EQUAL(Signature->HandledData.UsedEventsOnUnits.size(),2);
 

--- a/src/tests/functions/tests.generators/GeneratorsFunc.cpp
+++ b/src/tests/functions/tests.generators/GeneratorsFunc.cpp
@@ -86,7 +86,7 @@ BEGIN_FUNCTION_SIGNATURE("tests.generators")
   DECLARE_REQUIRED_VAR("tests.random[double]","TestUnits","random value from generators for tests","");
   DECLARE_REQUIRED_VAR("tests.interp[double]","TestUnits","interpolated value from generators for tests","");
 
-  DECLARE_REQUIRED_PREVVAR("tests.fixedprev[vector]","TestUnits","fixed value from generators at a previous time step for tests","");
+  DECLARE_REQUIRED_VAR("tests.fixedprev[vector]","TestUnits","fixed value from generators at a previous time step for tests","");
 
 END_FUNCTION_SIGNATURE
 


### PR DESCRIPTION
- Removed required PREVVAR from signature macros
- Updated consistency checking in Engine and ProjectChecker classes
- Updated information display for variables in OpenFLUID-Builder
- Removed deprecated pretestConsistency in Engine class
- Adapted tests

(closes #154)
