### PR TITLE
Added initialize method in OpenFLUID-Builder extensions

### DIFF
--- a/src/apps/openfluid-builder/base/ProjectModule.hpp
+++ b/src/apps/openfluid-builder/base/ProjectModule.hpp
@@ -79,6 +79,10 @@ class RunConfigurationWidget;
 class OutputsWidget;
 
 
+namespace openfluid { namespace builderext {
+  class PluggableModelessExtension;
+} }
+
 
 class ProjectModule : public AbstractModule
 {
@@ -130,7 +134,7 @@ class ProjectModule : public AbstractModule
 
   private slots:
 
-    void releaseModelessExtension();
+    void releaseModelessExtension(openfluid::builderext::PluggableModelessExtension* Sender = NULL);
 
     void dispatchChanges(openfluid::builderext::FluidXUpdateFlags::Flags UpdateFlags);
 

--- a/src/apps/openfluid-builder/extensions/tests/tests.builderext.modal-spatial.classic/DummyModalSpatialClassic.hpp
+++ b/src/apps/openfluid-builder/extensions/tests/tests.builderext.modal-spatial.classic/DummyModalSpatialClassic.hpp
@@ -99,6 +99,11 @@ class DummyModalSpatialClassic : public openfluid::builderext::PluggableModalExt
 
     ~DummyModalSpatialClassic();
 
+    bool initialize()
+    {
+      return true;
+    }
+
 };
 
 

--- a/src/apps/openfluid-builder/extensions/tests/tests.builderext.modeless-other.simple/DummyModelessOtherSimple.cpp
+++ b/src/apps/openfluid-builder/extensions/tests/tests.builderext.modeless-other.simple/DummyModelessOtherSimple.cpp
@@ -87,6 +87,12 @@ class DummyModelessOtherSimple : public openfluid::builderext::PluggableModeless
     {
       new QLabel("test",this);
     }
+
+    bool initialize()
+    {
+      return true;
+    }
+
 };
 
 

--- a/src/apps/openfluid-builder/extensions/tests/tests.builderext.workspace-other.simple/DummyWorkspaceOtherSimple.hpp
+++ b/src/apps/openfluid-builder/extensions/tests/tests.builderext.workspace-other.simple/DummyWorkspaceOtherSimple.hpp
@@ -77,7 +77,11 @@ class DummyWorkspaceOtherSimple : public openfluid::builderext::PluggableWorkspa
 
     DummyWorkspaceOtherSimple();
 
-    QWidget* getWidget(QWidget* Parent);
+    bool initialize()
+    {
+      return true;
+    }
+
 };
 
 

--- a/src/openfluid/builderext/PluggableBuilderExtension.hpp
+++ b/src/openfluid/builderext/PluggableBuilderExtension.hpp
@@ -153,7 +153,7 @@ class DLLEXPORT PluggableBuilderExtension : public openfluid::ware::PluggableWar
     { return OPENFLUID_GetWareID(); }
 
 
-    virtual bool isReady() const = 0;
+    virtual bool initialize() = 0;
 };
 
 

--- a/src/openfluid/builderext/PluggableModalExtension.hpp
+++ b/src/openfluid/builderext/PluggableModalExtension.hpp
@@ -96,8 +96,9 @@ class DLLEXPORT PluggableModalExtension : public QDialog, public PluggableBuilde
     {  }
 
 
-    virtual bool isReady() const
+    virtual bool initialize()
     { return true; };
+
 };
 
 } } // namespaces

--- a/src/openfluid/builderext/PluggableModelessExtension.hpp
+++ b/src/openfluid/builderext/PluggableModelessExtension.hpp
@@ -95,7 +95,7 @@ class DLLEXPORT PluggableModelessExtension : public QDialog, public PluggableBui
     { }
 
 
-    virtual bool isReady() const
+    virtual bool initialize()
     { return true; };
 
 

--- a/src/openfluid/builderext/PluggableWorkspaceExtension.hpp
+++ b/src/openfluid/builderext/PluggableWorkspaceExtension.hpp
@@ -88,8 +88,10 @@ class DLLEXPORT PluggableWorkspaceExtension : public QWidget, public PluggableBu
       QWidget(NULL), PluggableBuilderExtension()
     { }
 
-    virtual bool isReady() const
+
+    virtual bool initialize()
     { return true; };
+
 };
 
 } } // namespaces


### PR DESCRIPTION
- Replaced isReady() const method by non-const initialize() method
- Introduced initialize step in OpenFLUID-Builder extensions launching
  system
- Cleaned code

(closes OpenFLUID/openfluid#296)
