### PR TITLE
Add of switch to enable/disable heavy tests

### DIFF
--- a/CMake.in.cmake
+++ b/CMake.in.cmake
@@ -141,6 +141,7 @@ ENDIF(VERSION_STATUS)
 
 
 ################### compilation and build ###################
+
 IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCC) 
   SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -Wextra")
   SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,16 @@
 #
 # Author : Jean-Christophe FABRE <fabrejc@supagro.inra.fr>
 #
+# Usage for debug build:
+#  cmake <path to sources>
 #
+# Usage for debug build with heavy tests enabled:
+#  cmake <path to sources> -DOPENFLUID_ENABLE_HEAVYTESTING=1
+#
+# Usage for release build:
+#  cmake <path to sources> -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=<prefix for install path>
+#
+
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
 
@@ -166,6 +175,11 @@ ELSE()
   MESSAGE(STATUS "Build OpenFLUID documentation : no") 
 ENDIF()
 
+IF(OPENFLUID_ENABLE_HEAVYTESTING)
+  MESSAGE(STATUS "Run heavy tests : yes")  
+ELSE()
+  MESSAGE(STATUS "Run heavy tests : no")  
+ENDIF()
   
 MESSAGE(STATUS "****************************************")
 


### PR DESCRIPTION
- Added OPENFLUID_ENABLE_HEAVYTESTING switch as a CMake variable,
  undefined by default.
