### PR TITLE
Fix of outputs tab update in Builder when saving a project as

### DIFF
--- a/src/apps/openfluid-builder/base/ProjectModule.cpp
+++ b/src/apps/openfluid-builder/base/ProjectModule.cpp
@@ -325,6 +325,7 @@ bool ProjectModule::whenSaveAsAsked()
                                   SaveAsDlg.getProjectFullPath()))
     {
       mp_DashboardFrame->refreshProjectInfos();
+      mp_OutputsTab->refreshOutputDir();
       emit savePerformed();
       return true;
     }

--- a/src/apps/openfluid-builder/outputs/OutputsWidget.cpp
+++ b/src/apps/openfluid-builder/outputs/OutputsWidget.cpp
@@ -58,10 +58,8 @@ OutputsWidget::OutputsWidget(QWidget* Parent, openfluid::fluidx::AdvancedFluidXD
 
   QDir("").mkpath(QString(openfluid::base::ProjectManager::getInstance()->getOutputDir().c_str()));
 
-  ui->OutputDirLabel->setText(QString(openfluid::base::ProjectManager::getInstance()->getOutputDir().c_str()));
-
   ui->OutputDirView->setModel(mp_FSModel);
-  ui->OutputDirView->setRootIndex(mp_FSModel->setRootPath(QString(openfluid::base::ProjectManager::getInstance()->getOutputDir().c_str())));
+  refreshOutputDir();
 
   connect(ui->OutputDirView,SIGNAL(doubleClicked(const QModelIndex&)),this,SLOT(tryToOpenFile(const QModelIndex&)));
   connect(ui->ClearButton,SIGNAL(clicked()),this,SLOT(clearOutputDir()));
@@ -77,6 +75,17 @@ OutputsWidget::OutputsWidget(QWidget* Parent, openfluid::fluidx::AdvancedFluidXD
 OutputsWidget::~OutputsWidget()
 {
   delete ui;
+}
+
+
+// =====================================================================
+// =====================================================================
+
+
+void OutputsWidget::refreshOutputDir() const
+{
+  ui->OutputDirLabel->setText(QString(openfluid::base::ProjectManager::getInstance()->getOutputDir().c_str()));
+  ui->OutputDirView->setRootIndex(mp_FSModel->setRootPath(QString(openfluid::base::ProjectManager::getInstance()->getOutputDir().c_str())));
 }
 
 

--- a/src/apps/openfluid-builder/outputs/OutputsWidget.hpp
+++ b/src/apps/openfluid-builder/outputs/OutputsWidget.hpp
@@ -74,11 +74,18 @@ class OutputsWidget : public WorkspaceWidget
 
     void tryToExploreOutputDir();
 
+
+  public slots:
+
+    void refreshOutputDir() const;
+
+
   public:
 
     OutputsWidget(QWidget* Parent, openfluid::fluidx::AdvancedFluidXDescriptor& AFXDesc);
 
     virtual ~OutputsWidget();
+
 };
 
 


### PR DESCRIPTION
(closes OpenFLUID/openfluid#347)
