### PR TITLE
Sync multiselect map/attribute/structure 349

### DIFF
--- a/src/apps/openfluid-builder/spatial/SpatialDomainWidget.cpp
+++ b/src/apps/openfluid-builder/spatial/SpatialDomainWidget.cpp
@@ -26,7 +26,7 @@
   license, and requires a written agreement between You and INRA.
   Licensees for Other Usage of OpenFLUID may use this file in accordance
   with the terms contained in the written agreement between You and INRA.
-
+  
 */
 
 
@@ -142,7 +142,8 @@ SpatialDomainWidget::SpatialDomainWidget(QWidget* Parent, openfluid::fluidx::Flu
   connect(ui->RemoveEventsButton,SIGNAL(clicked()),this,SLOT(removeEvents()));
 
   connect(ui->IDsListWidget,SIGNAL(currentRowChanged(int)),this,SLOT(updateUnitSelection(int)));
-  connect(ui->IDsListWidget,SIGNAL(currentRowChanged(int)),this,SLOT(updateAttSelectionFromIDsList(int)));
+  connect(ui->IDsListWidget,SIGNAL(itemSelectionChanged()),this,SLOT(updateSelectionFromIDsList()));
+  connect(ui->IDsListWidget,SIGNAL(itemSelectionChanged()),this,SLOT(refreshUnitField()));
 
   // map view
   // TODO to reactivate when units IDs display on map will be fully functional
@@ -166,7 +167,7 @@ SpatialDomainWidget::SpatialDomainWidget(QWidget* Parent, openfluid::fluidx::Flu
   connect(ui->AttributesTableWidget,SIGNAL(itemSelectionChanged()),this,
           SLOT(updateMapFromAttributesTableChange()));
   connect(ui->AttributesTableWidget,SIGNAL(itemSelectionChanged()),this,
-          SLOT(updateIDsListFromAttributesTableChange()));
+          SLOT(updateIDsListSelectionFromAttributesTableChange()));
 
   refresh();
 
@@ -422,13 +423,30 @@ void SpatialDomainWidget::refreshClassStructure()
 // =====================================================================
 
 
+void SpatialDomainWidget::updateRemoveUnitButtonText(int ID)
+{
+    if (ID >= 0 && ui->IDsListWidget->selectedItems().size() == 1)
+    {
+      ui->RemoveUnitButton->setText(tr("Remove unit %1 from %2 class").arg(ID).arg(m_ActiveClass));
+    }
+    else
+    {
+      ui->RemoveUnitButton->setText(tr("Remove selected units from %2 class").arg(m_ActiveClass));
+    }
+}
+
+
+// =====================================================================
+// =====================================================================
+
+
 void SpatialDomainWidget::updateUnitSelection(int Row)
 {
   if (Row >= 0)
   {
     openfluid::core::UnitID_t ID = ui->IDsListWidget->item(Row)->data(Qt::UserRole).toInt();
 
-    ui->RemoveUnitButton->setText(tr("Remove unit %1 from %2 class").arg(ID).arg(m_ActiveClass));
+    updateRemoveUnitButtonText(ID);
 
     const openfluid::fluidx::SpatialUnitDescriptor& UnitDesc = m_Domain.spatialUnit(m_ActiveClass.toStdString(),ID);
 
@@ -563,6 +581,30 @@ openfluid::core::UnitID_t SpatialDomainWidget::getUnitIDFromAttributesTableRow(i
 // =====================================================================
 
 
+void SpatialDomainWidget::refreshUnitField()
+{
+  unsigned int NItems = ui->IDsListWidget->selectedItems().size();
+  if (NItems > 1)
+  {
+    // Disable unit fields if several items selected
+    ui->UnitWidget->setEnabled(false);
+    updateRemoveUnitButtonText(-1); //-1 calls the multiselection message
+  }
+  else
+  {
+    ui->UnitWidget->setEnabled(true);
+    if (NItems == 1)
+    {
+      updateRemoveUnitButtonText(ui->IDsListWidget->selectedItems().last()->data(Qt::UserRole).toInt());
+    }
+  }
+}
+
+
+// =====================================================================
+// =====================================================================
+
+
 openfluid::core::UnitID_t SpatialDomainWidget::getUnitIDFromIDsListRow(int Row)
 {
   return (openfluid::core::UnitID_t)ui->IDsListWidget->item(Row)->data(Qt::UserRole).toInt();
@@ -573,26 +615,57 @@ openfluid::core::UnitID_t SpatialDomainWidget::getUnitIDFromIDsListRow(int Row)
 // =====================================================================
 
 
-void SpatialDomainWidget::updateAttSelectionFromIDsList(int Row)
+std::set<openfluid::core::UnitID_t> SpatialDomainWidget::getAttributeSelectedUnitSet()
 {
-  if (Row >= 0)
+  std::set<openfluid::core::UnitID_t> AttSelectedIDs;
+  for (QTableWidgetItem * item : ui->AttributesTableWidget->selectedItems())
   {
-    bool IsIDDiscrepancy = true;
-    int AttributeCurrentRow = ui->AttributesTableWidget->currentRow();
-    if (AttributeCurrentRow >= 0)
+    AttSelectedIDs.insert(getUnitIDFromAttributesTableRow(item->row()));
+  }
+  return AttSelectedIDs;
+}
+
+
+// =====================================================================
+// =====================================================================
+
+
+bool SpatialDomainWidget::isIDsListAndAttributeSelDiscrepancy()
+{
+  QList<QListWidgetItem *> IDsListSelItems = ui->IDsListWidget->selectedItems();
+  bool IsDiscrepancy = true;
+  std::set<openfluid::core::UnitID_t> IDsListSelIDs;
+  for (QListWidgetItem * item : IDsListSelItems)
+  {
+    IDsListSelIDs.insert(getUnitIDFromIDsListRow(ui->IDsListWidget->row(item)));
+  }
+
+  if (IDsListSelIDs == getAttributeSelectedUnitSet())
+  {
+      IsDiscrepancy = false;
+  }
+  return IsDiscrepancy;
+}
+
+
+// =====================================================================
+// =====================================================================
+
+
+void SpatialDomainWidget::updateSelectionFromIDsList()
+{
+  // Update attribute table if change detected
+  if (isIDsListAndAttributeSelDiscrepancy())
+  {
+    ui->AttributesTableWidget->clearSelection();
+    disconnect(ui->AttributesTableWidget,SIGNAL(itemSelectionChanged()),this,
+               SLOT(updateIDsListSelectionFromAttributesTableChange()));
+    for (QListWidgetItem * item : ui->IDsListWidget->selectedItems())
     {
-      IsIDDiscrepancy = getUnitIDFromAttributesTableRow(AttributeCurrentRow) != getUnitIDFromIDsListRow(Row);
+      ui->AttributesTableWidget->selectRow(ui->IDsListWidget->row(item));
     }
-    if (IsIDDiscrepancy)
-    {
-      // disconnect necessary to avoid cell replacement by full row
-      disconnect(ui->AttributesTableWidget,SIGNAL(itemSelectionChanged()),this,
-                  SLOT(updateIDsListFromAttributesTableChange()));
-      ui->AttributesTableWidget->clearSelection();
-      ui->AttributesTableWidget->selectRow(Row);
-      connect(ui->AttributesTableWidget,SIGNAL(itemSelectionChanged()),this,
-                SLOT(updateIDsListFromAttributesTableChange()));
-    }
+    connect(ui->AttributesTableWidget,SIGNAL(itemSelectionChanged()),this,
+            SLOT(updateIDsListSelectionFromAttributesTableChange()));
   }
 }
 
@@ -934,24 +1007,40 @@ void SpatialDomainWidget::addUnit()
 
 void SpatialDomainWidget::removeUnit()
 {
-  int ID = ui->IDsListWidget->currentItem()->data(Qt::UserRole).toInt();
+  QList<QListWidgetItem *> IDsListSelectedItems = ui->IDsListWidget->selectedItems();
 
   bool OK = true;
 
   if (openfluid::base::PreferencesManager::instance()->isBuilderSpatialUnitsRemovalConfirm())
   {
+    QString ToRemoveString;
+    if (IDsListSelectedItems.size() == 1)
+    {
+      int ID = IDsListSelectedItems.last()->data(Qt::UserRole).toInt();
+      ToRemoveString = tr("You are removing the unit %1 of class %2.\n"
+                          "All connections and attributes units related to this unit will be lost.\n\n"
+                         ).arg(ID).arg(m_ActiveClass);
+    }
+    else
+    {
+      ToRemoveString = tr("You are removing several units of class %2.\n"
+                          "All connections and attributes units related to these units will be lost.\n\n"
+                         ).arg(m_ActiveClass);
+    }
+
     OK = (QMessageBox::question(QApplication::activeWindow(),
                                 "OpenFLUID-Builder",
-                                tr("You are removing the unit %1 of class %2.\n"
-                                    "All connections and attributes units related to this unit will be lost.\n\n"
-                                    "Proceed anyway?").arg(ID).arg(m_ActiveClass),
-                                    QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok);
+                                ToRemoveString + tr("Proceed anyway?"),
+                                     QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok);
   }
 
   if (OK)
   {
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-    m_Domain.deleteUnit(m_ActiveClass.toStdString(),ID);
+    for (QListWidgetItem * item : IDsListSelectedItems)
+    {
+      m_Domain.deleteUnit(m_ActiveClass.toStdString(), item->data(Qt::UserRole).toInt());
+    }
     if (!m_Domain.isClassNameExists(m_ActiveClass.toStdString())) m_ActiveClass = "";
 
     refresh();
@@ -1355,18 +1444,14 @@ void SpatialDomainWidget::updateSelectionFromMap()
     MapSelectedIDs.insert(dynamic_cast<MapItemGraphics*>(item)->getUnitID());
   }
 
-  std::set<openfluid::core::UnitID_t> AttSelectedIDs;
-  for (QTableWidgetItem * item : ui->AttributesTableWidget->selectedItems())
-  {
-    AttSelectedIDs.insert(getUnitIDFromAttributesTableRow(item->row()));
-  }
-
-  if (MapSelectedIDs == AttSelectedIDs) {
+  if (MapSelectedIDs == getAttributeSelectedUnitSet()) {
       IsDiscrepancy = false;
   }
 
   if (!MapSelectedItems.isEmpty() && IsDiscrepancy)
   {
+    disconnect(ui->AttributesTableWidget,SIGNAL(itemSelectionChanged()),this,
+        SLOT(updateMapFromAttributesTableChange()));
     ui->AttributesTableWidget->clearSelection();
     for (QGraphicsItem * item : MapSelectedItems)
     {
@@ -1379,6 +1464,8 @@ void SpatialDomainWidget::updateSelectionFromMap()
         }
       }
     }
+    connect(ui->AttributesTableWidget,SIGNAL(itemSelectionChanged()),this,
+          SLOT(updateMapFromAttributesTableChange()));
   }
 }
 
@@ -1387,63 +1474,37 @@ void SpatialDomainWidget::updateSelectionFromMap()
 // =====================================================================
 
 
-void SpatialDomainWidget::updateIDsListFromAttributesTableChange()
+void SpatialDomainWidget::updateIDsListSelectionFromAttributesTableChange()
 {
-  std::set<unsigned int> SelectedRows;
-  QList<QTableWidgetItem *> AttSelectedItems = ui->AttributesTableWidget->selectedItems();
-  bool IsCurrentID = false;
-  openfluid::core::UnitID_t CurrentID;
-  if (ui->AttributesTableWidget->currentRow() >= 0)
+  QList<QTableWidgetItem *> AttSelItems = ui->AttributesTableWidget->selectedItems();
+  if (!AttSelItems.isEmpty() && isIDsListAndAttributeSelDiscrepancy())
   {
-    IsCurrentID = true;
-    CurrentID = getUnitIDFromAttributesTableRow(ui->AttributesTableWidget->currentRow());
-  }
+    int CurrentIDRow = ui->IDsListWidget->currentRow();
+    bool IsCurrentRowInSelection = false;
+    disconnect(ui->IDsListWidget,SIGNAL(itemSelectionChanged()),this,SLOT(updateSelectionFromIDsList()));
+    ui->IDsListWidget->clearSelection();
 
-  bool IsCurrentIDInSelection = false;
-  for (QTableWidgetItem * item : AttSelectedItems)
-  {
-    // Check if current is in selected for ID structure list
-    SelectedRows.insert(item->row());
-    if (IsCurrentID && getUnitIDFromAttributesTableRow(item->row()) == CurrentID)
+    for (QTableWidgetItem * item : AttSelItems)
     {
-      IsCurrentIDInSelection = true;
-    }
-  }
-
-  if (IsCurrentID)
-  {
-    // first selected id picked if current id not in selection
-    if (!IsCurrentIDInSelection && !AttSelectedItems.empty())
-    {
-      CurrentID = getUnitIDFromAttributesTableRow(ui->AttributesTableWidget->selectedItems().first()->row());
-    }
-    // Update ID structure list selected row if not already the one selected
-    bool IsIDDiscrepancy = true;
-    int IDsListCurrentRow = ui->IDsListWidget->currentRow();
-    if (IDsListCurrentRow >= 0)
-    {
-      IsIDDiscrepancy = CurrentID != getUnitIDFromIDsListRow(IDsListCurrentRow);
-    }
-    if (IsIDDiscrepancy)
-    {
-      for (int i=0; i<ui->IDsListWidget->count();i++)
+      ui->IDsListWidget->item(item->row())->setSelected(true);
+      if (item->row()==CurrentIDRow)
       {
-        if (getUnitIDFromIDsListRow(i) == CurrentID)
-        {
-          ui->IDsListWidget->setCurrentRow(i);
-        }
+          IsCurrentRowInSelection = true;
       }
     }
-    if (SelectedRows.size() > 1)
+
+    if (!IsCurrentRowInSelection)
     {
-      ui->tab->setEnabled(false);
+      ui->IDsListWidget->setCurrentItem(ui->IDsListWidget->selectedItems().first());
     }
-    else
-    {
-      ui->tab->setEnabled(true);
-    }
+    connect(ui->IDsListWidget,SIGNAL(itemSelectionChanged()),this,SLOT(updateSelectionFromIDsList()));
   }
 }
+
+
+// =====================================================================
+// =====================================================================
+
 
 void SpatialDomainWidget::updateMapFromAttributesTableChange()
 {

--- a/src/apps/openfluid-builder/spatial/SpatialDomainWidget.hpp
+++ b/src/apps/openfluid-builder/spatial/SpatialDomainWidget.hpp
@@ -26,7 +26,7 @@
   license, and requires a written agreement between You and INRA.
   Licensees for Other Usage of OpenFLUID may use this file in accordance
   with the terms contained in the written agreement between You and INRA.
-
+  
 */
 
 
@@ -101,15 +101,17 @@ class SpatialDomainWidget : public WorkspaceWidget
 
     void updateSelectionFromMap();
 
-    void updateAttSelectionFromIDsList(int Row);
+    void updateSelectionFromIDsList();
 
-    void updateIDsListFromAttributesTableChange();
+    void updateIDsListSelectionFromAttributesTableChange();
 
     void updateMapFromAttributesTableChange();
 
     void updateFluidXAttributeFromCellValue(int Row, int Column);
 
     void updateFluidXProcessOrder(int PcsOrd);
+
+    void refreshUnitField();
 
   private:
 
@@ -124,6 +126,8 @@ class SpatialDomainWidget : public WorkspaceWidget
     MapScene* mp_MapScene;
 
     void setActiveClass(const QString& ClassName);
+
+    void updateRemoveUnitButtonText(int ID);
 
     void refreshClassStructure();
 
@@ -142,6 +146,10 @@ class SpatialDomainWidget : public WorkspaceWidget
     openfluid::core::UnitID_t getUnitIDFromAttributesTableRow(int Row);
 
     openfluid::core::UnitID_t getUnitIDFromIDsListRow(int Row);
+
+    std::set<openfluid::core::UnitID_t> getAttributeSelectedUnitSet();
+
+    bool isIDsListAndAttributeSelDiscrepancy();
 
     void setAllMapLayersVisible();
 

--- a/src/apps/openfluid-builder/spatial/SpatialDomainWidget.hpp
+++ b/src/apps/openfluid-builder/spatial/SpatialDomainWidget.hpp
@@ -26,7 +26,7 @@
   license, and requires a written agreement between You and INRA.
   Licensees for Other Usage of OpenFLUID may use this file in accordance
   with the terms contained in the written agreement between You and INRA.
-  
+
 */
 
 
@@ -42,6 +42,7 @@
 
 
 #include <QWidget>
+#include <QTableWidgetItem>
 
 #include <openfluid/fluidx/SpatialDomainDescriptor.hpp>
 #include <openfluid/fluidx/DatastoreDescriptor.hpp>
@@ -100,14 +101,15 @@ class SpatialDomainWidget : public WorkspaceWidget
 
     void updateSelectionFromMap();
 
-    void updateIDsSelectionFromAttributesTableRow(int Row);
+    void updateAttSelectionFromIDsList(int Row);
 
-    void updateIDsSelectionFromAttributesTableCell(int Row, int Column);
+    void updateIDsListFromAttributesTableChange();
+
+    void updateMapFromAttributesTableChange();
 
     void updateFluidXAttributeFromCellValue(int Row, int Column);
 
     void updateFluidXProcessOrder(int PcsOrd);
-
 
   private:
 
@@ -136,6 +138,10 @@ class SpatialDomainWidget : public WorkspaceWidget
     int getClassIndex(const QString& ClassName);
 
     QStringList getClassesOrderedStringList();
+
+    openfluid::core::UnitID_t getUnitIDFromAttributesTableRow(int Row);
+
+    openfluid::core::UnitID_t getUnitIDFromIDsListRow(int Row);
 
     void setAllMapLayersVisible();
 

--- a/src/apps/openfluid-builder/spatial/SpatialDomainWidget.ui
+++ b/src/apps/openfluid-builder/spatial/SpatialDomainWidget.ui
@@ -201,154 +201,178 @@
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::ExtendedSelection</enum>
+             </property>
             </widget>
            </item>
            <item>
-            <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_5">
-               <item>
-                <widget class="QLabel" name="label_3">
-                 <property name="text">
-                  <string>Process order:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="PcsOrderSpinBox"/>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <widget class="QFrame" name="frame">
-               <property name="frameShape">
-                <enum>QFrame::HLine</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Sunken</enum>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label">
-               <property name="text">
-                <string>Connections:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_7">
-               <item>
-                <widget class="QTableWidget" name="ConnectionsTableWidget">
-                 <property name="editTriggers">
-                  <set>QAbstractItemView::NoEditTriggers</set>
-                 </property>
-                 <property name="selectionMode">
-                  <enum>QAbstractItemView::SingleSelection</enum>
-                 </property>
-                 <property name="selectionBehavior">
-                  <enum>QAbstractItemView::SelectRows</enum>
-                 </property>
-                 <attribute name="horizontalHeaderStretchLastSection">
-                  <bool>true</bool>
-                 </attribute>
-                 <attribute name="verticalHeaderVisible">
-                  <bool>false</bool>
-                 </attribute>
-                 <column>
-                  <property name="text">
-                   <string>Connection type</string>
+            <widget class="QWidget" name="UnitWidget" native="true">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <layout class="QGridLayout" name="gridLayout">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0">
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_5">
+                  <item>
+                   <widget class="QLabel" name="label_3">
+                    <property name="text">
+                     <string>Process order:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QSpinBox" name="PcsOrderSpinBox"/>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <widget class="QFrame" name="frame">
+                  <property name="frameShape">
+                   <enum>QFrame::HLine</enum>
                   </property>
-                 </column>
-                 <column>
-                  <property name="text">
-                   <string>Units class</string>
+                  <property name="frameShadow">
+                   <enum>QFrame::Sunken</enum>
                   </property>
-                 </column>
-                 <column>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label">
                   <property name="text">
-                   <string>Unit ID</string>
+                   <string>Connections:</string>
                   </property>
-                 </column>
-                </widget>
-               </item>
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_3">
-                 <item>
-                  <widget class="QPushButton" name="AddConnectionButton">
-                   <property name="minimumSize">
-                    <size>
-                     <width>32</width>
-                     <height>32</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>32</width>
-                     <height>32</height>
-                    </size>
-                   </property>
-                   <property name="toolTip">
-                    <string>Add connection</string>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="RemoveConnectionButton">
-                   <property name="minimumSize">
-                    <size>
-                     <width>32</width>
-                     <height>32</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>32</width>
-                     <height>32</height>
-                    </size>
-                   </property>
-                   <property name="toolTip">
-                    <string>Remove selected connection</string>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="verticalSpacer_2">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-            </layout>
+                 </widget>
+                </item>
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_7">
+                  <item>
+                   <widget class="QTableWidget" name="ConnectionsTableWidget">
+                    <property name="editTriggers">
+                     <set>QAbstractItemView::NoEditTriggers</set>
+                    </property>
+                    <property name="selectionMode">
+                     <enum>QAbstractItemView::SingleSelection</enum>
+                    </property>
+                    <property name="selectionBehavior">
+                     <enum>QAbstractItemView::SelectRows</enum>
+                    </property>
+                    <attribute name="horizontalHeaderStretchLastSection">
+                     <bool>true</bool>
+                    </attribute>
+                    <attribute name="verticalHeaderVisible">
+                     <bool>false</bool>
+                    </attribute>
+                    <column>
+                     <property name="text">
+                      <string>Connection type</string>
+                     </property>
+                    </column>
+                    <column>
+                     <property name="text">
+                      <string>Units class</string>
+                     </property>
+                    </column>
+                    <column>
+                     <property name="text">
+                      <string>Unit ID</string>
+                     </property>
+                    </column>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QVBoxLayout" name="verticalLayout_3">
+                    <item>
+                     <widget class="QPushButton" name="AddConnectionButton">
+                      <property name="minimumSize">
+                       <size>
+                        <width>32</width>
+                        <height>32</height>
+                       </size>
+                      </property>
+                      <property name="maximumSize">
+                       <size>
+                        <width>32</width>
+                        <height>32</height>
+                       </size>
+                      </property>
+                      <property name="toolTip">
+                       <string>Add connection</string>
+                      </property>
+                      <property name="text">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="RemoveConnectionButton">
+                      <property name="minimumSize">
+                       <size>
+                        <width>32</width>
+                        <height>32</height>
+                       </size>
+                      </property>
+                      <property name="maximumSize">
+                       <size>
+                        <width>32</width>
+                        <height>32</height>
+                       </size>
+                      </property>
+                      <property name="toolTip">
+                       <string>Remove selected connection</string>
+                      </property>
+                      <property name="text">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="verticalSpacer_2">
+                      <property name="orientation">
+                       <enum>Qt::Vertical</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>20</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
            </item>
           </layout>
          </item>


### PR DESCRIPTION
Synchronized multi-selection between map and attribute table

* Defined attribute table as reference widget
* Handled multi-selection communication between map and table (both directions)

Structure list handles multiselection

* Changed selection mode in structure list
* Adapted communication from/to attribute table for multi-selection
* Disabled unit widget in case of multi-selection
* Adapted delete button and action

(closes #349)