### PR TITLE
Sync multiselect map/attribute/structure 349

### DIFF
--- a/src/apps/openfluid-builder/spatial/SpatialDomainWidget.hpp
+++ b/src/apps/openfluid-builder/spatial/SpatialDomainWidget.hpp
@@ -26,7 +26,7 @@
   license, and requires a written agreement between You and INRA.
   Licensees for Other Usage of OpenFLUID may use this file in accordance
   with the terms contained in the written agreement between You and INRA.
-
+  
 */
 
 
@@ -101,15 +101,17 @@ class SpatialDomainWidget : public WorkspaceWidget
 
     void updateSelectionFromMap();
 
-    void updateAttSelectionFromIDsList(int Row);
+    void updateSelectionFromIDsList();
 
-    void updateIDsListFromAttributesTableChange();
+    void updateIDsListSelectionFromAttributesTableChange();
 
     void updateMapFromAttributesTableChange();
 
     void updateFluidXAttributeFromCellValue(int Row, int Column);
 
     void updateFluidXProcessOrder(int PcsOrd);
+
+    void refreshUnitField();
 
   private:
 
@@ -124,6 +126,8 @@ class SpatialDomainWidget : public WorkspaceWidget
     MapScene* mp_MapScene;
 
     void setActiveClass(const QString& ClassName);
+
+    void updateRemoveUnitButtonText(int ID);
 
     void refreshClassStructure();
 
@@ -142,6 +146,10 @@ class SpatialDomainWidget : public WorkspaceWidget
     openfluid::core::UnitID_t getUnitIDFromAttributesTableRow(int Row);
 
     openfluid::core::UnitID_t getUnitIDFromIDsListRow(int Row);
+
+    std::set<openfluid::core::UnitID_t> getAttributeSelectedUnitSet();
+
+    bool isIDsListAndAttributeSelDiscrepancy();
 
     void setAllMapLayersVisible();
 

--- a/src/apps/openfluid-builder/spatial/SpatialDomainWidget.hpp
+++ b/src/apps/openfluid-builder/spatial/SpatialDomainWidget.hpp
@@ -26,7 +26,7 @@
   license, and requires a written agreement between You and INRA.
   Licensees for Other Usage of OpenFLUID may use this file in accordance
   with the terms contained in the written agreement between You and INRA.
-  
+
 */
 
 
@@ -42,6 +42,7 @@
 
 
 #include <QWidget>
+#include <QTableWidgetItem>
 
 #include <openfluid/fluidx/SpatialDomainDescriptor.hpp>
 #include <openfluid/fluidx/DatastoreDescriptor.hpp>
@@ -100,14 +101,15 @@ class SpatialDomainWidget : public WorkspaceWidget
 
     void updateSelectionFromMap();
 
-    void updateIDsSelectionFromAttributesTableRow(int Row);
+    void updateAttSelectionFromIDsList(int Row);
 
-    void updateIDsSelectionFromAttributesTableCell(int Row, int Column);
+    void updateIDsListFromAttributesTableChange();
+
+    void updateMapFromAttributesTableChange();
 
     void updateFluidXAttributeFromCellValue(int Row, int Column);
 
     void updateFluidXProcessOrder(int PcsOrd);
-
 
   private:
 
@@ -136,6 +138,10 @@ class SpatialDomainWidget : public WorkspaceWidget
     int getClassIndex(const QString& ClassName);
 
     QStringList getClassesOrderedStringList();
+
+    openfluid::core::UnitID_t getUnitIDFromAttributesTableRow(int Row);
+
+    openfluid::core::UnitID_t getUnitIDFromIDsListRow(int Row);
 
     void setAllMapLayersVisible();
 

--- a/src/apps/openfluid-builder/spatial/SpatialDomainWidget.ui
+++ b/src/apps/openfluid-builder/spatial/SpatialDomainWidget.ui
@@ -201,154 +201,178 @@
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::ExtendedSelection</enum>
+             </property>
             </widget>
            </item>
            <item>
-            <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_5">
-               <item>
-                <widget class="QLabel" name="label_3">
-                 <property name="text">
-                  <string>Process order:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="PcsOrderSpinBox"/>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <widget class="QFrame" name="frame">
-               <property name="frameShape">
-                <enum>QFrame::HLine</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Sunken</enum>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label">
-               <property name="text">
-                <string>Connections:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_7">
-               <item>
-                <widget class="QTableWidget" name="ConnectionsTableWidget">
-                 <property name="editTriggers">
-                  <set>QAbstractItemView::NoEditTriggers</set>
-                 </property>
-                 <property name="selectionMode">
-                  <enum>QAbstractItemView::SingleSelection</enum>
-                 </property>
-                 <property name="selectionBehavior">
-                  <enum>QAbstractItemView::SelectRows</enum>
-                 </property>
-                 <attribute name="horizontalHeaderStretchLastSection">
-                  <bool>true</bool>
-                 </attribute>
-                 <attribute name="verticalHeaderVisible">
-                  <bool>false</bool>
-                 </attribute>
-                 <column>
-                  <property name="text">
-                   <string>Connection type</string>
+            <widget class="QWidget" name="UnitWidget" native="true">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <layout class="QGridLayout" name="gridLayout">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0">
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_5">
+                  <item>
+                   <widget class="QLabel" name="label_3">
+                    <property name="text">
+                     <string>Process order:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QSpinBox" name="PcsOrderSpinBox"/>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <widget class="QFrame" name="frame">
+                  <property name="frameShape">
+                   <enum>QFrame::HLine</enum>
                   </property>
-                 </column>
-                 <column>
-                  <property name="text">
-                   <string>Units class</string>
+                  <property name="frameShadow">
+                   <enum>QFrame::Sunken</enum>
                   </property>
-                 </column>
-                 <column>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label">
                   <property name="text">
-                   <string>Unit ID</string>
+                   <string>Connections:</string>
                   </property>
-                 </column>
-                </widget>
-               </item>
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_3">
-                 <item>
-                  <widget class="QPushButton" name="AddConnectionButton">
-                   <property name="minimumSize">
-                    <size>
-                     <width>32</width>
-                     <height>32</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>32</width>
-                     <height>32</height>
-                    </size>
-                   </property>
-                   <property name="toolTip">
-                    <string>Add connection</string>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="RemoveConnectionButton">
-                   <property name="minimumSize">
-                    <size>
-                     <width>32</width>
-                     <height>32</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>32</width>
-                     <height>32</height>
-                    </size>
-                   </property>
-                   <property name="toolTip">
-                    <string>Remove selected connection</string>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="verticalSpacer_2">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-            </layout>
+                 </widget>
+                </item>
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_7">
+                  <item>
+                   <widget class="QTableWidget" name="ConnectionsTableWidget">
+                    <property name="editTriggers">
+                     <set>QAbstractItemView::NoEditTriggers</set>
+                    </property>
+                    <property name="selectionMode">
+                     <enum>QAbstractItemView::SingleSelection</enum>
+                    </property>
+                    <property name="selectionBehavior">
+                     <enum>QAbstractItemView::SelectRows</enum>
+                    </property>
+                    <attribute name="horizontalHeaderStretchLastSection">
+                     <bool>true</bool>
+                    </attribute>
+                    <attribute name="verticalHeaderVisible">
+                     <bool>false</bool>
+                    </attribute>
+                    <column>
+                     <property name="text">
+                      <string>Connection type</string>
+                     </property>
+                    </column>
+                    <column>
+                     <property name="text">
+                      <string>Units class</string>
+                     </property>
+                    </column>
+                    <column>
+                     <property name="text">
+                      <string>Unit ID</string>
+                     </property>
+                    </column>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QVBoxLayout" name="verticalLayout_3">
+                    <item>
+                     <widget class="QPushButton" name="AddConnectionButton">
+                      <property name="minimumSize">
+                       <size>
+                        <width>32</width>
+                        <height>32</height>
+                       </size>
+                      </property>
+                      <property name="maximumSize">
+                       <size>
+                        <width>32</width>
+                        <height>32</height>
+                       </size>
+                      </property>
+                      <property name="toolTip">
+                       <string>Add connection</string>
+                      </property>
+                      <property name="text">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="RemoveConnectionButton">
+                      <property name="minimumSize">
+                       <size>
+                        <width>32</width>
+                        <height>32</height>
+                       </size>
+                      </property>
+                      <property name="maximumSize">
+                       <size>
+                        <width>32</width>
+                        <height>32</height>
+                       </size>
+                      </property>
+                      <property name="toolTip">
+                       <string>Remove selected connection</string>
+                      </property>
+                      <property name="text">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="verticalSpacer_2">
+                      <property name="orientation">
+                       <enum>Qt::Vertical</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>20</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
            </item>
           </layout>
          </item>


### PR DESCRIPTION
Synchronized multi-selection between map and attribute table

* Defined attribute table as reference widget
* Handled multi-selection communication between map and table (both directions)

Structure list handles multiselection

* Changed selection mode in structure list
* Adapted communication from/to attribute table for multi-selection
* Disabled unit widget in case of multi-selection
* Adapted delete button and action

(closes #349)