### PR TITLE
Enable line width (#404) and hide fill color setting for non-surface layers (#827)

### DIFF
--- a/src/apps/openfluid-builder/spatial/MapScene.cpp
+++ b/src/apps/openfluid-builder/spatial/MapScene.cpp
@@ -98,14 +98,15 @@ void MapScene::addLayer(const openfluid::fluidx::DatastoreItemDescriptor* DSItem
           if (m_Scale <= 0)
           {
             throw openfluid::base::FrameworkException(OPENFLUID_CODE_LOCATION,
-                                                    "Scene scale negative or null. Can't apply corresponding scaling.");
+                                                      "Scene scale negative or null. Can't apply corresponding scaling."
+                                                      );
           }
           else
           {
             ScaledLineWidth /= m_Scale;
           }
         }
-        catch (std::exception & E)
+        catch (const std::exception & E)
         {
           std::cerr << "std ERROR: " << E.what() << std::endl;
           ScaledLineWidth = 0;

--- a/src/apps/openfluid-builder/spatial/MapScene.hpp
+++ b/src/apps/openfluid-builder/spatial/MapScene.hpp
@@ -65,6 +65,8 @@ class MapScene : public QGraphicsScene
     QList<MapItemGraphics*>* m_ActiveLayer;
 
     void updateActiveLayer();
+    
+    float m_Scale = -1;
 
 
   public slots:
@@ -84,6 +86,8 @@ class MapScene : public QGraphicsScene
                      QColor FillColor);
 
     void setActiveLayer(const QString& UnitClass);
+    
+    void setScale(const float Scale);
 
     void clear();
 };

--- a/src/apps/openfluid-builder/spatial/MapView.cpp
+++ b/src/apps/openfluid-builder/spatial/MapView.cpp
@@ -60,8 +60,14 @@ void MapView::wheelEvent(QWheelEvent* Event)
     emit automaticViewEnabled(false);
 
     // TODO zoom center on mouse cursor
-    if (Event->delta() < 0) scale(0.9,0.9);
-    else scale(1.1,1.1);
+    if (Event->delta() < 0)
+    {
+      scale(0.9,0.9);
+    }
+    else
+    {
+      scale(1.1,1.1);
+    }
     emit scaling();
   }
   else

--- a/src/apps/openfluid-builder/spatial/MapView.cpp
+++ b/src/apps/openfluid-builder/spatial/MapView.cpp
@@ -62,6 +62,7 @@ void MapView::wheelEvent(QWheelEvent* Event)
     // TODO zoom center on mouse cursor
     if (Event->delta() < 0) scale(0.9,0.9);
     else scale(1.1,1.1);
+    emit scaling();
   }
   else
     QGraphicsView::wheelEvent(Event);
@@ -101,4 +102,5 @@ void MapView::enableAutomaticView(bool Enabled)
 void MapView::fitViewToItems()
 {
   fitInView(scene()->itemsBoundingRect(),Qt::KeepAspectRatio);
+  emit scaling();
 }

--- a/src/apps/openfluid-builder/spatial/MapView.hpp
+++ b/src/apps/openfluid-builder/spatial/MapView.hpp
@@ -64,6 +64,8 @@ class MapView : public QGraphicsView
 
     void automaticViewEnabled(bool);
 
+    void scaling();
+
 
   public slots:
 

--- a/src/apps/openfluid-builder/spatial/SpatialDomainWidget.cpp
+++ b/src/apps/openfluid-builder/spatial/SpatialDomainWidget.cpp
@@ -802,37 +802,36 @@ void SpatialDomainWidget::refreshClassData()
 
 void SpatialDomainWidget::refreshMapScale()
 {
-   //transform().m11() is the scaling value of the QGraphicsView to display the QGraphicsScene
-   float ViewScale = ui->GlobalMapView->transform().m11();
-   //here we check that there is a scaling (scale != 1) before redrawing the map
+  //transform().m11() is the scaling value of the QGraphicsView to display the QGraphicsScene
+  float ViewScale = ui->GlobalMapView->transform().m11();
+  //here we check that there is a scaling (scale != 1) before redrawing the map
   if (ViewScale != 1 && m_IsCustomLineWidth)
   {
-    
-      mp_MapScene->setScale(ViewScale);
-      // signal disconnection since map clearing will reset the selection on map
-      disconnect(mp_MapScene,SIGNAL(selectionChanged()),this,SLOT(updateSelectionFromMap()));
-      mp_MapScene->clear();
+    mp_MapScene->setScale(ViewScale);
+    // signal disconnection since map clearing will reset the selection on map
+    disconnect(mp_MapScene,SIGNAL(selectionChanged()),this,SLOT(updateSelectionFromMap()));
+    mp_MapScene->clear();
 
-      QVBoxLayout* Layout = dynamic_cast<QVBoxLayout*>(ui->UnitsClassAreaContents->layout());
+    QVBoxLayout* Layout = dynamic_cast<QVBoxLayout*>(ui->UnitsClassAreaContents->layout());
 
-      for (int i=Layout->count()-2; i>=0;i--)
+    for (int i=Layout->count()-2; i>=0;i--)
+    {
+      UnitsClassWidget* ClassW = dynamic_cast<UnitsClassWidget*>(Layout->itemAt(i)->widget());
+
+      if (ClassW->layerSource() != nullptr && ClassW->isLayerVisible())
       {
-        UnitsClassWidget* ClassW = dynamic_cast<UnitsClassWidget*>(Layout->itemAt(i)->widget());
-
-        if (ClassW->layerSource() != nullptr && ClassW->isLayerVisible())
-        {
-          mp_MapScene->addLayer(ClassW->layerSource(),
-                                -i,
-                                ClassW->getLineWidth(),
-                                ClassW->getLineColor(),
-                                ClassW->getFillColor());
-        }
+        mp_MapScene->addLayer(ClassW->layerSource(),
+                              -i,
+                              ClassW->getLineWidth(),
+                              ClassW->getLineColor(),
+                              ClassW->getFillColor());
       }
-      connect(mp_MapScene,SIGNAL(selectionChanged()),this,SLOT(updateSelectionFromMap()));
-      mp_MapScene->setActiveLayer(m_ActiveClass);
+    }
+    connect(mp_MapScene,SIGNAL(selectionChanged()),this,SLOT(updateSelectionFromMap()));
+    mp_MapScene->setActiveLayer(m_ActiveClass);
       
-      // refresh the selection on map
-      updateMapFromAttributesTableChange();
+    // refresh the selection on map
+    updateMapFromAttributesTableChange();
   }
 }
 
@@ -856,7 +855,7 @@ void SpatialDomainWidget::refreshMap()
     UnitsClassWidget* ClassW = dynamic_cast<UnitsClassWidget*>(Layout->itemAt(i)->widget());
 
     ClassW->linkToDatastoreItem(m_Datastore.getItems(ClassW->getClassName().toStdString(),
-                                  openfluid::core::UnstructuredValue::GeoVectorValue));
+                                openfluid::core::UnstructuredValue::GeoVectorValue));
 
     if (ClassW->layerSource() != nullptr && ClassW->isLayerVisible())
     {

--- a/src/apps/openfluid-builder/spatial/SpatialDomainWidget.hpp
+++ b/src/apps/openfluid-builder/spatial/SpatialDomainWidget.hpp
@@ -120,6 +120,8 @@ class SpatialDomainWidget : public WorkspaceWidget
     openfluid::fluidx::SpatialDomainDescriptor& m_Domain;
 
     openfluid::fluidx::DatastoreDescriptor& m_Datastore;
+    
+    bool m_IsCustomLineWidth = false;
 
     QString m_ActiveClass;
 
@@ -155,6 +157,8 @@ class SpatialDomainWidget : public WorkspaceWidget
 
 
   public slots:
+  
+    void refreshMapScale();
 
     void refresh();
 

--- a/src/apps/openfluid-builder/spatial/UnitsClassWidget.cpp
+++ b/src/apps/openfluid-builder/spatial/UnitsClassWidget.cpp
@@ -98,16 +98,16 @@ UnitsClassWidget::UnitsClassWidget(const QString& ClassName,
       openfluid::base::RunContextManager::instance()->getProjectConfigValue("builder.spatial.unitsclasses",
                                                                             m_ClassName+".linewidth");
 
-  if (TmpLineWidth.type() == QVariant::String)
+  if (TmpLineWidth.type() == QVariant::String || TmpLineWidth.type() == QVariant::Int)
   {
-    m_LineWidth = TmpLineWidth.toString().toInt();
+    m_LineWidth = TmpLineWidth.toInt();
   }
   else
   {
     m_LineWidth = 0;
-
     openfluid::base::RunContextManager::instance()->setProjectConfigValue("builder.spatial.unitsclasses",
-                                                                   m_ClassName+".linewidth",m_LineWidth);
+                                                                          m_ClassName+".linewidth",
+                                                                          QVariant(m_LineWidth));
   }
 
 
@@ -333,7 +333,7 @@ void UnitsClassWidget::changeLineWidth(int Width)
   m_LineWidth = Width;
 
   openfluid::base::RunContextManager::instance()->setProjectConfigValue("builder.spatial.unitsclasses",
-                                                                        m_ClassName+".linewidth",m_LineWidth);
+                                                                        m_ClassName+".linewidth",QVariant(m_LineWidth));
 
   emit styleChanged(m_ClassName);
 }
@@ -358,10 +358,10 @@ bool UnitsClassWidget::isLayer2D(openfluid::fluidx::DatastoreItemDescriptor* DSI
   if (DSItemDesc->getType() == openfluid::core::UnstructuredValue::GeoVectorValue)
   {
     openfluid::core::DatastoreItem* DSItem = new openfluid::core::DatastoreItem(DSItemDesc->getID(),
-                                                  DSItemDesc->getPrefixPath(),
-                                                  DSItemDesc->getRelativePath(),
-                                                  DSItemDesc->getType(),
-                                                  DSItemDesc->getUnitsClass());
+                                                                                DSItemDesc->getPrefixPath(),
+                                                                                DSItemDesc->getRelativePath(),
+                                                                                DSItemDesc->getType(),
+                                                                                DSItemDesc->getUnitsClass());
 
     openfluid::core::GeoVectorValue* VectorData = dynamic_cast<openfluid::core::GeoVectorValue*>(DSItem->value());
 

--- a/src/apps/openfluid-builder/spatial/UnitsClassWidget.cpp
+++ b/src/apps/openfluid-builder/spatial/UnitsClassWidget.cpp
@@ -102,7 +102,7 @@ UnitsClassWidget::UnitsClassWidget(const QString& ClassName,
   }
   else
   {
-    m_LineWidth = 1;
+    m_LineWidth = 0;
 
     openfluid::base::RunContextManager::instance()->setProjectConfigValue("builder.spatial.unitsclasses",
                                                                    m_ClassName+".linewidth",m_LineWidth);
@@ -146,10 +146,6 @@ UnitsClassWidget::UnitsClassWidget(const QString& ClassName,
   ui->LineColorButton->setStyleSheet(QString(m_ColorButtonStyleSheet).arg(m_LineColor.name()));
   ui->FillColorButton->setStyleSheet(QString(m_ColorButtonStyleSheet).arg(m_FillColor.name()));
   ui->LineWidthSpinBox->setValue(m_LineWidth);
-
-  // TODO re-enable line width settings
-  ui->LineWidthLabel->setVisible(false);
-  ui->LineWidthSpinBox->setVisible(false);
 
   connect(ui->VisibleCheckBox,SIGNAL(toggled(bool)),this,SLOT(changeVisible()));
   connect(ui->LineColorButton,SIGNAL(clicked()),this,SLOT(changeLineColor()));
@@ -337,7 +333,7 @@ void UnitsClassWidget::changeLineWidth(int Width)
   openfluid::base::RunContextManager::instance()->setProjectConfigValue("builder.spatial.unitsclasses",
                                                                         m_ClassName+".linewidth",m_LineWidth);
 
-  //emit styleChanged(m_ClassName);
+  emit styleChanged(m_ClassName);
 }
 
 

--- a/src/apps/openfluid-builder/spatial/UnitsClassWidget.cpp
+++ b/src/apps/openfluid-builder/spatial/UnitsClassWidget.cpp
@@ -46,6 +46,7 @@
 #include <openfluid/core/GeoVectorValue.hpp>
 #include <openfluid/core/DatastoreItem.hpp>
 #include <openfluid/ui/common/UIHelpers.hpp>
+#include <openfluid/utils/GDALCompatibility.hpp>
 
 #include "ui_UnitsClassWidget.h"
 #include "UnitsClassWidget.hpp"
@@ -367,7 +368,7 @@ bool UnitsClassWidget::isLayer2D(openfluid::fluidx::DatastoreItemDescriptor* DSI
 
     if (VectorData->data() != nullptr && VectorData->containsField("OFLD_ID",0))
     {
-      return OGR_GT_IsSurface(VectorData->layer()->GetGeomType());
+      return GDALIsSurface_COMPAT(VectorData->data());
     }
   }
   return false;

--- a/src/apps/openfluid-builder/spatial/UnitsClassWidget.hpp
+++ b/src/apps/openfluid-builder/spatial/UnitsClassWidget.hpp
@@ -94,6 +94,8 @@ class UnitsClassWidget : public QFrame
      QColor m_FillColor;
 
      openfluid::fluidx::DatastoreItemDescriptor* mp_LayerSource;
+     
+     bool isLayer2D(openfluid::fluidx::DatastoreItemDescriptor* DSItemDesc);
 
      void mousePressEvent(QMouseEvent* Event);
 

--- a/src/apps/openfluid-builder/spatial/UnitsClassWidget.ui
+++ b/src/apps/openfluid-builder/spatial/UnitsClassWidget.ui
@@ -240,7 +240,7 @@
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_3">
+            <widget class="QLabel" name="FillColorLabel">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                <horstretch>0</horstretch>

--- a/src/openfluid/utils/GDALCompatibility.hpp
+++ b/src/openfluid/utils/GDALCompatibility.hpp
@@ -209,4 +209,17 @@
 #endif
 
 
+/**
+  Macro for compatibility of surface object detection
+  @param _M_data the GDALDataset_COMPAT object
+  @return a boolean about 2D state of objects of the dataset
+*/
+#if (GDAL_VERSION_MAJOR >= 2)
+  #define GDALIsSurface_COMPAT(_M_data) OGR_GT_IsSurface(_M_data->GetLayer(0)->GetGeomType())
+#else
+  #define GDALIsSurface_COMPAT(_M_data) (_M_data->GetLayer(0)->GetGeomType() == wkbPolygon || \
+                                         _M_data->GetLayer(0)->GetGeomType() == wkbMultiPolygon)
+#endif
+
+
 #endif /* __OPENFLUID_UTILS_GDALCOMPATIBILITY_HPP__ */


### PR DESCRIPTION
Enabling of line width setting in map view (#404)

* Uncommented widgets and signals related to line width
* Implemented a cosmetic width display (constant width regardless of the zoom)

No fill color in builder map for non-surface layers (#827)

* Detected layer dimension in units class widget
* Hid fill color fields when not relevant
* Handled GDAL versions 1 and 2 for geometries

(closes #404 and #827)