### PR TITLE
Color correction of settings buttons for map visual in builder

### DIFF
--- a/src/apps/openfluid-builder/spatial/UnitsClassWidget.cpp
+++ b/src/apps/openfluid-builder/spatial/UnitsClassWidget.cpp
@@ -54,7 +54,7 @@
 
 
 QString UnitsClassWidget::m_ColorButtonStyleSheet =
-    "QPushButton{ background-color : %1;}";
+    "QPushButton{ background-color : %1; border: 1px solid #8f8f91; border-radius: 3px;}";
 /*    "QPushButton{ background-color : %1; border-radius : 6px; border: 1px solid #777777;}"
     "QPushButton:pressed{ background-color : %1; border-radius : 6px; border: 1px solid #777777;}"
     "QPushButton:default{ background-color : %1; border-radius : 2px; border: 1px solid #777777;}";*/

--- a/src/apps/openfluid-builder/spatial/UnitsClassWidget.ui
+++ b/src/apps/openfluid-builder/spatial/UnitsClassWidget.ui
@@ -234,6 +234,9 @@
                <height>20</height>
               </size>
              </property>
+             <property name="cursor">
+              <cursorShape>PointingHandCursor</cursorShape>
+             </property>
              <property name="text">
               <string notr="true"/>
              </property>
@@ -259,6 +262,9 @@
                <width>20</width>
                <height>20</height>
               </size>
+             </property>
+             <property name="cursor">
+              <cursorShape>PointingHandCursor</cursorShape>
              </property>
              <property name="text">
               <string/>


### PR DESCRIPTION
* Removed the default border on button that added a shadow on the color
* Changed cursor to hand when the mouse is over a color setting button