### PR TITLE
Fix line width double increment in Builder

### DIFF
--- a/src/apps/openfluid-builder/spatial/UnitsClassWidget.ui
+++ b/src/apps/openfluid-builder/spatial/UnitsClassWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>250</width>
+    <width>264</width>
     <height>234</height>
    </rect>
   </property>
@@ -190,6 +190,9 @@
          </item>
          <item>
           <layout class="QFormLayout" name="formLayout">
+           <property name="labelAlignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
            <item row="0" column="0">
             <widget class="QLabel" name="LineWidthLabel">
              <property name="text">
@@ -200,22 +203,28 @@
            <item row="0" column="1">
             <widget class="QSpinBox" name="LineWidthSpinBox">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
              <property name="maximumSize">
               <size>
-               <width>16777215</width>
+               <width>50</width>
                <height>16777215</height>
               </size>
+             </property>
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string notr="true">px</string>
              </property>
              <property name="minimum">
               <number>1</number>
              </property>
              <property name="maximum">
-              <number>400</number>
+              <number>100</number>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
* Removed the line width spinbox buttons
* Changed the UnitsClassWidget buttons alignment to right

(closes OpenFLUID/openfluid#867)