### PR TITLE
Fix closing buttons behaviour in the run simulation dialog

### DIFF
--- a/src/openfluid/ui/common/RunSimulationDialog.cpp
+++ b/src/openfluid/ui/common/RunSimulationDialog.cpp
@@ -169,7 +169,11 @@ RunSimulationDialog::~RunSimulationDialog()
 
 void RunSimulationDialog::closeEvent(QCloseEvent *event)
 {
-  event->ignore();
+  // uses the bottom "close" button as reference to know if closing is authorized
+  if (!ui->ButtonBox->button(QDialogButtonBox::Close)->isEnabled())
+  {
+    event->ignore();
+  }
 }
 
 


### PR DESCRIPTION
* Added a condition to ignore exit call only when exit botton button is disabled

(closes OpenFLUID/openfluid#868)