### PR TITLE
Fix of inconsistent parameter saving behavior for empty values

### DIFF
--- a/src/openfluid/fluidx/FluidXDescriptor.cpp
+++ b/src/openfluid/fluidx/FluidXDescriptor.cpp
@@ -1013,9 +1013,11 @@ std::string FluidXDescriptor::getParamsAsStr(const openfluid::ware::WareParams_t
   {
     std::string EscapedValueStr =
         openfluid::tools::escapeXMLEntities(QString::fromStdString(it->second.data())).toStdString();
-
-    ParamsStr += (m_IndentStr + m_IndentStr + m_IndentStr + "<param name=\""
-                 + it->first + "\" value=\"" + EscapedValueStr + "\"/>\n");
+    if (!EscapedValueStr.empty())
+    {
+      ParamsStr += (m_IndentStr + m_IndentStr + m_IndentStr + "<param name=\""
+                   + it->first + "\" value=\"" + EscapedValueStr + "\"/>\n");
+    }
   }
 
   return ParamsStr;


### PR DESCRIPTION
* Added a non-empty string check when writing parameters to file

(closes OpenFLUID/openfluid#897)