### PR TITLE
Fix of wrong project path management in Builder

### DIFF
--- a/src/apps/openfluid-builder/base/ProjectCentral.cpp
+++ b/src/apps/openfluid-builder/base/ProjectCentral.cpp
@@ -59,7 +59,7 @@ ProjectCentral* ProjectCentral::mp_Instance = nullptr;
 
 
 ProjectCentral::ProjectCentral(const QString& PrjPath):
-  mp_FXDesc(nullptr), m_PrjPath(PrjPath)
+  mp_FXDesc(nullptr)
 {
   mp_FXDesc = new openfluid::fluidx::FluidXDescriptor(&m_IOListener);
 
@@ -206,7 +206,8 @@ void ProjectCentral::run(RunMode Mode)
   }
   else if (Mode == RunMode::CLI)
   {
-    openfluid::ui::common::RunCLISimulationDialog RunDlg(QApplication::activeWindow(),m_PrjPath);
+    openfluid::ui::common::RunCLISimulationDialog RunDlg(QApplication::activeWindow(),
+                                                         QString::fromStdString(CtxtMan->getProjectPath()));
     RunDlg.execute();
   }
   else

--- a/src/apps/openfluid-builder/base/ProjectCentral.hpp
+++ b/src/apps/openfluid-builder/base/ProjectCentral.hpp
@@ -60,8 +60,6 @@ class ProjectCentral : QObject
 
     openfluid::fluidx::FluidXDescriptor* mp_FXDesc;
 
-    QString m_PrjPath;
-
     ProjectCheckInfos m_CheckInfos;
 
     openfluid::base::IOListener m_IOListener;


### PR DESCRIPTION
* Updated path variable when running in CLI mode
* Removed unnecessary project path member in ProjectCentral class

(closes OpenFLUID/openfluid#969)